### PR TITLE
feat: 增加 Abaqus MCP 无界面后台桥接

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### 新增
 
+- 隐藏运行的 `Abaqus cae noGUI` MCP 后台桥接及 start/status/stop 命令；
+- Windows 使用只读进程句柄检查 PID，避免 Python 3.13 的 `os.kill` 兼容异常；
+- 11 项后台桥接和 Windows 进程检查测试，离线测试总数增加到 79 项；
 - MCP 插件心跳、状态新鲜度和 Abaqus 进程检测；
 - MCP 防卡启动器与显式 `mcp-setup --repair --yes` 修复流程；
 - 11 项不启动 Abaqus 的 MCP 防卡测试，离线测试总数增加到 68 项；

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - 检测 `abqpy` 安装状态和版本兼容性；
 - 检测 Abaqus MCP 文件、Codex 注册和本地启动状态；
 - 检测 MCP 心跳和 Abaqus 进程，并在桥接离线时快速返回，避免工具持续转圈；
+- 支持在隐藏的 `Abaqus cae noGUI` 进程中运行 MCP，避免 CAE 图形界面被轮询占用；
 - 在用户明确确认后安装或注册固定版本的 Abaqus MCP；
 - 选择入门、论文复现、科研、生产或教学场景；
 - 检测本机 Ollama 或 LM Studio，并把中文需求转换为受约束的矩形板 JSON；
@@ -78,6 +79,16 @@ py -m venv .venv
 ```
 
 详细原因和排查步骤见 [Abaqus MCP 一直转圈排查](docs/mcp-troubleshooting.md)。
+
+如果 GUI 模式仍导致进度条和鼠标转圈，使用无界面后台桥接：
+
+```powershell
+.\.venv\Scripts\python.exe -m abaqus_codex mcp-headless start
+.\.venv\Scripts\python.exe -m abaqus_codex mcp-headless status
+.\.venv\Scripts\python.exe -m abaqus_codex mcp-headless stop
+```
+
+该模式使用独立 Abaqus/CAE 许可证会话，不显示操作界面，也不会预先打开任何私人模型。
 
 保存使用场景：
 
@@ -226,7 +237,7 @@ CI 同时覆盖 Linux、Windows、Python 3.10 和 Python 3.13。当前真实 Aba
 
 - 缺陷和功能建议使用仓库内置 Issue 表单；
 - 所有改动通过分支和 Pull Request 提交；
-- GitHub Actions 自动运行语法检查和 68 项离线测试；
+- GitHub Actions 自动运行语法检查和 79 项离线测试；
 - Dependabot 每月检查 Python 与 GitHub Actions 依赖；
 - 版本变化记录在 [CHANGELOG](CHANGELOG.md)；
 - 发布前按照 [发布清单](RELEASING.md) 完成真实 Abaqus 验证；

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,6 +36,7 @@ Python 3 生成中文 report.md
 - `abqpy_environment.py`：abqpy 版本匹配；
 - `mcp_environment.py`：MCP 文件、Codex 注册、导入验证和 Abaqus 插件心跳检查；
 - `mcp_guard.py`：工具调用前检查心跳与进程，桥接离线时快速返回；
+- `mcp_headless.py`：隐藏启动、检查和优雅停止独立 Abaqus noGUI 桥接；
 - `mcp_setup.py`：经明确确认后的固定版本安装和防卡注册修复；
 - `doctor.py`：综合体检；
 - `configuration.py`：输入校验；

--- a/docs/mcp-troubleshooting.md
+++ b/docs/mcp-troubleshooting.md
@@ -50,3 +50,29 @@ Abaqus MCP 包含两个独立部分：Codex 启动的 MCP 服务器，以及 Aba
 - 不要把 `commands` 目录里的 JSON 当作脚本手工执行。
 
 防卡启动器解决的是“离线时长时间等待”，不会自动启动 Abaqus，也不会掩盖插件自身错误。
+
+## GUI 一直显示进度条怎么办
+
+`Background` 在部分 Abaqus 版本中无法稳定轮询；`Cooperative` 和 `Blocking` 又可能占用 CAE 图形主线程，使顶部进度条来回移动、鼠标转圈。
+
+这种情况可以停止 GUI 中的 MCP，改用独立的无界面后台桥接：
+
+```powershell
+.\.venv\Scripts\python.exe -m abaqus_codex mcp-headless start
+```
+
+它通过 `Abaqus cae noGUI` 启动隐藏进程，不打开私人 `.cae` 文件。Codex 可以在该进程的空白模型数据库中执行经过确认的建模脚本、保存模型或提交作业。
+
+查看状态：
+
+```powershell
+.\.venv\Scripts\python.exe -m abaqus_codex mcp-headless status
+```
+
+完成后优雅停止：
+
+```powershell
+.\.venv\Scripts\python.exe -m abaqus_codex mcp-headless stop
+```
+
+标准输出和错误日志位于 `%USERPROFILE%\.abaqus-mcp\headless_bridge_*.log`。该模式会使用一个独立 Abaqus/CAE 许可证会话；许可证不足时启动会失败并在日志中说明。

--- a/src/abaqus_codex/cli.py
+++ b/src/abaqus_codex/cli.py
@@ -56,6 +56,26 @@ def _build_parser() -> argparse.ArgumentParser:
         help="将已有 Abaqus MCP 注册替换为防卡启动器；必须同时使用 --yes。",
     )
 
+    headless_parser = subparsers.add_parser(
+        "mcp-headless", help="在隐藏的 Abaqus noGUI 进程中运行 MCP 桥接。"
+    )
+    headless_subparsers = headless_parser.add_subparsers(
+        dest="headless_command", required=True
+    )
+    headless_start = headless_subparsers.add_parser(
+        "start", help="启动无界面后台桥接。"
+    )
+    headless_start.add_argument(
+        "--timeout", type=int, default=60, help="等待插件心跳的秒数。"
+    )
+    headless_stop = headless_subparsers.add_parser(
+        "stop", help="优雅停止无界面后台桥接。"
+    )
+    headless_stop.add_argument(
+        "--timeout", type=int, default=20, help="等待后台进程退出的秒数。"
+    )
+    headless_subparsers.add_parser("status", help="查看无界面后台桥接状态。")
+
     configure_parser = subparsers.add_parser(
         "configure", help="选择使用场景并保存本地配置。"
     )
@@ -161,6 +181,23 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             from abaqus_codex.mcp_setup import main as mcp_setup_main
 
             return mcp_setup_main(confirmed=args.yes, repair=args.repair)
+
+        if args.command == "mcp-headless":
+            from abaqus_codex.mcp_headless import (
+                inspect_headless_bridge,
+                print_headless_status,
+                start_headless_bridge,
+                stop_headless_bridge,
+            )
+
+            if args.headless_command == "start":
+                result = start_headless_bridge(timeout_seconds=args.timeout)
+            elif args.headless_command == "stop":
+                result = stop_headless_bridge(timeout_seconds=args.timeout)
+            else:
+                result = inspect_headless_bridge()
+            print_headless_status(result)
+            return 0 if result["running"] or args.headless_command == "stop" else 1
 
         if args.command == "configure":
             scenario = args.scenario or prompt_scenario()

--- a/src/abaqus_codex/mcp_guard.py
+++ b/src/abaqus_codex/mcp_guard.py
@@ -8,6 +8,7 @@ import math
 import os
 import sys
 import time
+import ctypes
 from pathlib import Path
 from typing import Callable, Dict, Optional
 
@@ -22,6 +23,8 @@ def process_is_running(pid: int) -> bool:
 
     if isinstance(pid, bool) or not isinstance(pid, int) or pid <= 0:
         return False
+    if os.name == "nt":
+        return _windows_process_is_running(pid)
     try:
         # 信号 0 只检查进程，不会结束 Abaqus。
         os.kill(pid, 0)
@@ -33,6 +36,28 @@ def process_is_running(pid: int) -> bool:
     except OSError:
         return False
     return True
+
+
+def _windows_process_is_running(pid: int) -> bool:
+    """在 Windows 上用只读进程句柄检查 PID，避免 os.kill 的兼容异常。"""
+
+    process_query_limited_information = 0x1000
+    try:
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        open_process = kernel32.OpenProcess
+        open_process.argtypes = [ctypes.c_ulong, ctypes.c_int, ctypes.c_ulong]
+        open_process.restype = ctypes.c_void_p
+        close_handle = kernel32.CloseHandle
+        close_handle.argtypes = [ctypes.c_void_p]
+        close_handle.restype = ctypes.c_int
+        handle = open_process(process_query_limited_information, 0, pid)
+        if handle:
+            close_handle(handle)
+            return True
+        # ERROR_ACCESS_DENIED 表示进程存在，只是当前权限不能打开。
+        return ctypes.get_last_error() == 5
+    except (AttributeError, OSError, SystemError, ValueError):
+        return False
 
 
 def inspect_bridge_status(

--- a/src/abaqus_codex/mcp_headless.py
+++ b/src/abaqus_codex/mcp_headless.py
@@ -1,0 +1,268 @@
+# -*- coding: utf-8 -*-
+"""管理不显示 Abaqus/CAE 图形界面的 MCP 后台桥接。"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+from typing import Dict, Optional
+
+from abaqus_codex.environment import find_abaqus_command
+from abaqus_codex.mcp_guard import inspect_bridge_status, process_is_running
+
+
+MANAGED_HEADLESS_MARKER = "ABAQUS_CODEX_ASSISTANT_MANAGED_HEADLESS_BRIDGE_V1"
+HEADLESS_SCRIPT_NAME = "mcp_headless_bridge.py"
+HEADLESS_PID_NAME = "headless_bridge_launcher.json"
+HEADLESS_STDOUT_NAME = "headless_bridge_stdout.log"
+HEADLESS_STDERR_NAME = "headless_bridge_stderr.log"
+
+
+HEADLESS_BRIDGE_SCRIPT = '''# -*- coding: utf-8 -*-
+"""由 Abaqus Codex Assistant 管理的无界面 MCP 桥接入口。"""
+
+# ABAQUS_CODEX_ASSISTANT_MANAGED_HEADLESS_BRIDGE_V1
+# Abaqus 启动钩子会先加载 MCP 插件。这里停止不稳定的后台线程，
+# 再在独立 noGUI 进程中使用稳定的阻塞轮询；不会占用用户的 CAE 界面。
+if 'mcp_stop' in globals():
+    mcp_stop()
+
+if 'mcp_loop' not in globals():
+    raise RuntimeError('Abaqus MCP plugin was not loaded by abaqus_v6.env')
+
+print('Starting managed headless Abaqus MCP bridge...')
+mcp_loop(sleep_interval=0.1)
+'''
+
+
+class McpHeadlessError(RuntimeError):
+    """表示后台 MCP 桥接无法安全启动或停止。"""
+
+
+def mcp_home_path(home: Optional[Path] = None) -> Path:
+    """返回 MCP 工作目录。"""
+
+    return (home or (Path.home() / ".abaqus-mcp")).resolve()
+
+
+def _write_managed_script(home: Path) -> Path:
+    """写入通用 noGUI 脚本，不覆盖用户自己的同名文件。"""
+
+    path = home / HEADLESS_SCRIPT_NAME
+    if path.is_file():
+        existing = path.read_text(encoding="utf-8", errors="replace")
+        if MANAGED_HEADLESS_MARKER not in existing:
+            raise McpHeadlessError(
+                "发现非本项目管理的后台脚本，未覆盖：{0}".format(path)
+            )
+        if existing.replace("\r\n", "\n") == HEADLESS_BRIDGE_SCRIPT.replace(
+            "\r\n", "\n"
+        ):
+            return path
+    path.write_text(HEADLESS_BRIDGE_SCRIPT, encoding="utf-8")
+    return path
+
+
+def _abaqus_arguments(command: Path, script: Path) -> list[str]:
+    """构造固定参数命令，避免把用户文本交给 shell 解释。"""
+
+    no_gui_argument = "noGUI={0}".format(script)
+    if os.name == "nt" and command.suffix.lower() in {".bat", ".cmd"}:
+        return [
+            os.environ.get("COMSPEC", "cmd.exe"),
+            "/d",
+            "/c",
+            str(command),
+            "cae",
+            no_gui_argument,
+        ]
+    return [str(command), "cae", no_gui_argument]
+
+
+def _read_launcher(home: Path) -> Dict[str, object]:
+    """读取本项目记录的后台启动器信息。"""
+
+    try:
+        data = json.loads((home / HEADLESS_PID_NAME).read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def inspect_headless_bridge(home: Optional[Path] = None) -> Dict[str, object]:
+    """同时检查启动器进程和 Abaqus 插件心跳。"""
+
+    root = mcp_home_path(home)
+    launcher = _read_launcher(root)
+    launcher_pid = launcher.get("launcher_pid")
+    launcher_running = process_is_running(launcher_pid)
+    bridge = inspect_bridge_status(root / "status.json")
+    bridge_pid = launcher.get("bridge_pid")
+    bridge_process_running = bool(
+        bridge_pid
+        and bridge.get("pid") == bridge_pid
+        and process_is_running(bridge_pid)
+    )
+    managed_process_running = bool(launcher_running or bridge_process_running)
+    return {
+        "running": bool(managed_process_running and bridge["responsive"]),
+        "launcher_pid": launcher_pid,
+        "launcher_running": launcher_running,
+        "bridge_pid": bridge_pid,
+        "bridge_process_running": bridge_process_running,
+        "managed_process_running": managed_process_running,
+        "bridge": bridge,
+        "stdout_log": str(root / HEADLESS_STDOUT_NAME),
+        "stderr_log": str(root / HEADLESS_STDERR_NAME),
+    }
+
+
+def start_headless_bridge(
+    home: Optional[Path] = None,
+    abaqus_command: Optional[Path] = None,
+    timeout_seconds: int = 60,
+) -> Dict[str, object]:
+    """隐藏启动独立 noGUI 进程，并等待插件心跳真正可用。"""
+
+    if timeout_seconds <= 0:
+        raise McpHeadlessError("后台桥接启动超时必须大于零。")
+    root = mcp_home_path(home)
+    if not (root / "abaqus_mcp_plugin.py").is_file():
+        raise McpHeadlessError("没有找到 Abaqus MCP 插件，请先运行 mcp-setup。")
+
+    current = inspect_headless_bridge(root)
+    if current["running"]:
+        return current
+    current_bridge = current["bridge"]
+    if current_bridge["responsive"]:
+        raise McpHeadlessError(
+            "已有 Abaqus MCP 桥接在线；请先停止 CAE 中的 MCP，再启动后台模式。"
+        )
+
+    command = (abaqus_command or find_abaqus_command())
+    if command is None or not Path(command).is_file():
+        raise McpHeadlessError("没有找到 Abaqus 启动命令。")
+    script = _write_managed_script(root)
+    stop_file = root / "stop.flag"
+    if stop_file.exists():
+        stop_file.unlink()
+
+    stdout_path = root / HEADLESS_STDOUT_NAME
+    stderr_path = root / HEADLESS_STDERR_NAME
+    startupinfo = None
+    creationflags = 0
+    if os.name == "nt":
+        startupinfo = subprocess.STARTUPINFO()
+        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+        startupinfo.wShowWindow = subprocess.SW_HIDE
+        # BREAKAWAY 让后台 Abaqus 不随启动命令所在的宿主作业退出；
+        # NO_WINDOW 确保不弹出额外控制台窗口。DETACHED_PROCESS 会让
+        # 部分 Abaqus 批处理初始化停住，因此这里明确不使用它。
+        creationflags = (
+            subprocess.CREATE_NO_WINDOW
+            | subprocess.CREATE_NEW_PROCESS_GROUP
+            | subprocess.CREATE_BREAKAWAY_FROM_JOB
+        )
+
+    stdout_handle = stdout_path.open("ab")
+    stderr_handle = stderr_path.open("ab")
+    try:
+        process = subprocess.Popen(
+            _abaqus_arguments(Path(command), script),
+            cwd=str(root),
+            stdout=stdout_handle,
+            stderr=stderr_handle,
+            stdin=subprocess.DEVNULL,
+            startupinfo=startupinfo,
+            creationflags=creationflags,
+        )
+    except OSError as error:
+        raise McpHeadlessError("无法启动 Abaqus noGUI：{0}".format(error)) from error
+    finally:
+        stdout_handle.close()
+        stderr_handle.close()
+
+    launcher = {
+        "launcher_pid": process.pid,
+        "started_at": time.time(),
+        "abaqus_command": str(command),
+        "script": str(script),
+    }
+    (root / HEADLESS_PID_NAME).write_text(
+        json.dumps(launcher, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        if process.poll() is not None:
+            raise McpHeadlessError(
+                "Abaqus noGUI 提前退出，退出码 {0}。请检查日志：{1}".format(
+                    process.returncode, stderr_path
+                )
+            )
+        result = inspect_headless_bridge(root)
+        if result["running"]:
+            bridge_pid = result["bridge"].get("pid")
+            launcher["bridge_pid"] = bridge_pid
+            (root / HEADLESS_PID_NAME).write_text(
+                json.dumps(launcher, ensure_ascii=False, indent=2), encoding="utf-8"
+            )
+            return inspect_headless_bridge(root)
+        time.sleep(0.5)
+    raise McpHeadlessError(
+        "Abaqus noGUI 在 {0} 秒内没有建立心跳；进程可能仍在启动，请检查：{1}".format(
+            timeout_seconds, stderr_path
+        )
+    )
+
+
+def stop_headless_bridge(
+    home: Optional[Path] = None, timeout_seconds: int = 20
+) -> Dict[str, object]:
+    """发送停止文件并等待后台进程自行退出，不强制终止 Abaqus。"""
+
+    if timeout_seconds <= 0:
+        raise McpHeadlessError("后台桥接停止超时必须大于零。")
+    root = mcp_home_path(home)
+    before = inspect_headless_bridge(root)
+    if not before["managed_process_running"]:
+        return before
+    (root / "stop.flag").write_text("stop", encoding="ascii")
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        result = inspect_headless_bridge(root)
+        if not result["managed_process_running"]:
+            try:
+                (root / HEADLESS_PID_NAME).unlink()
+            except FileNotFoundError:
+                pass
+            return result
+        time.sleep(0.5)
+    raise McpHeadlessError(
+        "已发送停止信号，但后台进程未在 {0} 秒内退出；未强制结束进程。".format(
+            timeout_seconds
+        )
+    )
+
+
+def print_headless_status(result: Dict[str, object]) -> None:
+    """输出适合初学者阅读的后台桥接状态。"""
+
+    print("Abaqus MCP 无界面后台桥接")
+    print("----------------------------")
+    print("整体状态：{0}".format("在线" if result["running"] else "离线"))
+    print(
+        "启动器进程：{0}".format(
+            "运行中" if result["launcher_running"] else "未运行"
+        )
+    )
+    if result["launcher_pid"]:
+        print("启动器 PID：{0}".format(result["launcher_pid"]))
+    if result["bridge_pid"]:
+        print("Abaqus 内核 PID：{0}".format(result["bridge_pid"]))
+    print("插件心跳：{0}".format(result["bridge"]["message"]))
+    print("标准输出日志：{0}".format(result["stdout_log"]))
+    print("错误日志：{0}".format(result["stderr_log"]))

--- a/src/abaqus_codex/mcp_headless.py
+++ b/src/abaqus_codex/mcp_headless.py
@@ -66,11 +66,16 @@ def _write_managed_script(home: Path) -> Path:
     return path
 
 
-def _abaqus_arguments(command: Path, script: Path) -> list[str]:
-    """构造固定参数命令，避免把用户文本交给 shell 解释。"""
+def _abaqus_arguments(
+    command: Path,
+    script: Path,
+    system_name: Optional[str] = None,
+) -> list[str]:
+    """构造固定参数命令；可传入平台名，方便跨平台测试。"""
 
     no_gui_argument = "noGUI={0}".format(script)
-    if os.name == "nt" and command.suffix.lower() in {".bat", ".cmd"}:
+    current_system = os.name if system_name is None else system_name
+    if current_system == "nt" and command.suffix.lower() in {".bat", ".cmd"}:
         return [
             os.environ.get("COMSPEC", "cmd.exe"),
             "/d",

--- a/tests/test_mcp_guard.py
+++ b/tests/test_mcp_guard.py
@@ -4,11 +4,16 @@
 import json
 import tempfile
 import unittest
+import os
 from pathlib import Path
 from unittest.mock import patch
 
 from abaqus_codex.doctor import inspect_environment
-from abaqus_codex.mcp_guard import guarded_sender, inspect_bridge_status
+from abaqus_codex.mcp_guard import (
+    guarded_sender,
+    inspect_bridge_status,
+    process_is_running,
+)
 from abaqus_codex.mcp_setup import (
     MCP_SERVER_NAME,
     McpSetupError,
@@ -82,6 +87,16 @@ class McpBridgeStatusTests(unittest.TestCase):
             result = inspect_bridge_status(path, now=1000.0)
         self.assertFalse(result["responsive"])
         self.assertEqual(result["status"], "future")
+
+    def test_current_process_is_running(self):
+        """当前测试进程必须能在 Windows 和 Linux 上被安全识别。"""
+
+        self.assertTrue(process_is_running(os.getpid()))
+
+    def test_impossible_process_is_not_running(self):
+        """明显无效的高 PID 不应被误报为在线。"""
+
+        self.assertFalse(process_is_running(2147483647))
 
 
 class McpGuardSenderTests(unittest.TestCase):

--- a/tests/test_mcp_headless.py
+++ b/tests/test_mcp_headless.py
@@ -1,0 +1,174 @@
+# -*- coding: utf-8 -*-
+"""测试无界面 MCP 后台桥接，不真实启动 Abaqus。"""
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from abaqus_codex.mcp_headless import (
+    HEADLESS_PID_NAME,
+    McpHeadlessError,
+    _abaqus_arguments,
+    _write_managed_script,
+    inspect_headless_bridge,
+    start_headless_bridge,
+    stop_headless_bridge,
+)
+
+
+def offline_result():
+    """返回一份没有后台进程、插件也离线的状态。"""
+
+    return {
+        "running": False,
+        "launcher_pid": None,
+        "launcher_running": False,
+        "bridge_pid": None,
+        "bridge_process_running": False,
+        "managed_process_running": False,
+        "bridge": {"responsive": False, "message": "离线"},
+        "stdout_log": "stdout.log",
+        "stderr_log": "stderr.log",
+    }
+
+
+class HeadlessCommandTests(unittest.TestCase):
+    """确认不同平台的固定命令参数正确。"""
+
+    @patch("abaqus_codex.mcp_headless.os.name", "nt")
+    def test_windows_batch_uses_cmd(self):
+        """Windows 批处理必须交给 cmd.exe，但不拼接用户 shell 文本。"""
+
+        with patch.dict("os.environ", {"COMSPEC": r"C:\Windows\System32\cmd.exe"}):
+            args = _abaqus_arguments(
+                Path(r"C:\SIMULIA\Commands\abaqus.bat"),
+                Path(r"C:\Users\User\.abaqus-mcp\mcp_headless_bridge.py"),
+            )
+        self.assertEqual(args[1:3], ["/d", "/c"])
+        self.assertEqual(args[-2], "cae")
+        self.assertTrue(args[-1].startswith("noGUI="))
+
+    @patch("abaqus_codex.mcp_headless.os.name", "posix")
+    def test_regular_executable_uses_direct_arguments(self):
+        """非批处理命令应直接传递参数列表。"""
+
+        args = _abaqus_arguments(Path("/opt/abaqus"), Path("/tmp/bridge.py"))
+        self.assertEqual(args, ["/opt/abaqus", "cae", "noGUI=/tmp/bridge.py"])
+
+
+class HeadlessScriptTests(unittest.TestCase):
+    """确认项目脚本可更新，同时保护用户自己的文件。"""
+
+    def test_managed_script_is_created(self):
+        """首次启动应生成不含私人模型路径的通用脚本。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = _write_managed_script(Path(directory))
+            content = path.read_text(encoding="utf-8")
+        self.assertIn("mcp_loop", content)
+        self.assertNotIn("MODEL_PATH", content)
+
+    def test_unmanaged_script_is_not_overwritten(self):
+        """用户自己的同名脚本不能被自动覆盖。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            home = Path(directory)
+            (home / "mcp_headless_bridge.py").write_text(
+                "# user script", encoding="utf-8"
+            )
+            with self.assertRaises(McpHeadlessError):
+                _write_managed_script(home)
+
+
+class HeadlessLifecycleTests(unittest.TestCase):
+    """确认启动、状态和停止流程不会误操作其他 Abaqus 进程。"""
+
+    @patch("abaqus_codex.mcp_headless.inspect_bridge_status")
+    @patch("abaqus_codex.mcp_headless.process_is_running")
+    def test_status_requires_launcher_and_heartbeat(
+        self, process_mock, bridge_mock
+    ):
+        """启动器与插件心跳必须同时在线。"""
+
+        process_mock.return_value = True
+        bridge_mock.return_value = {
+            "responsive": True,
+            "message": "正常",
+            "pid": 5678,
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            home = Path(directory)
+            (home / HEADLESS_PID_NAME).write_text(
+                '{"launcher_pid": 1234, "bridge_pid": 5678}', encoding="utf-8"
+            )
+            result = inspect_headless_bridge(home)
+        self.assertTrue(result["running"])
+
+    def test_start_requires_installed_plugin(self):
+        """缺少插件时不能只启动一个无效的 Abaqus 进程。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(McpHeadlessError, "请先运行 mcp-setup"):
+                start_headless_bridge(Path(directory), timeout_seconds=1)
+
+    @patch("abaqus_codex.mcp_headless.inspect_headless_bridge")
+    def test_start_refuses_another_online_bridge(self, inspect_mock):
+        """CAE 图形桥接在线时不能再启动第二个命令消费者。"""
+
+        value = offline_result()
+        value["bridge"] = {"responsive": True, "message": "在线"}
+        inspect_mock.return_value = value
+        with tempfile.TemporaryDirectory() as directory:
+            home = Path(directory)
+            (home / "abaqus_mcp_plugin.py").write_text("# plugin", encoding="utf-8")
+            with self.assertRaisesRegex(McpHeadlessError, "已有"):
+                start_headless_bridge(home, timeout_seconds=1)
+
+    @patch("abaqus_codex.mcp_headless.subprocess.Popen")
+    @patch("abaqus_codex.mcp_headless.inspect_headless_bridge")
+    def test_start_waits_for_real_heartbeat(self, inspect_mock, popen_mock):
+        """只有后台进程和插件心跳都在线时才报告启动成功。"""
+
+        online = offline_result()
+        online.update(
+            {
+                "running": True,
+                "launcher_pid": 4321,
+                "launcher_running": True,
+                "managed_process_running": True,
+            }
+        )
+        online["bridge"] = {"responsive": True, "message": "正常", "pid": 8765}
+        final_online = dict(online)
+        final_online["bridge_pid"] = 8765
+        final_online["bridge_process_running"] = True
+        inspect_mock.side_effect = [offline_result(), online, final_online]
+        process = Mock(pid=4321)
+        process.poll.return_value = None
+        popen_mock.return_value = process
+        with tempfile.TemporaryDirectory() as directory:
+            home = Path(directory)
+            plugin = home / "abaqus_mcp_plugin.py"
+            command = home / "abaqus"
+            plugin.write_text("# plugin", encoding="utf-8")
+            command.write_text("", encoding="utf-8")
+            result = start_headless_bridge(
+                home, abaqus_command=command, timeout_seconds=1
+            )
+        self.assertTrue(result["running"])
+        self.assertEqual(popen_mock.call_count, 1)
+
+    @patch("abaqus_codex.mcp_headless.inspect_headless_bridge")
+    def test_stop_without_managed_launcher_is_noop(self, inspect_mock):
+        """没有本项目启动的后台进程时，停止命令不能影响 GUI Abaqus。"""
+
+        inspect_mock.return_value = offline_result()
+        with tempfile.TemporaryDirectory() as directory:
+            result = stop_headless_bridge(Path(directory), timeout_seconds=1)
+            self.assertFalse((Path(directory) / "stop.flag").exists())
+        self.assertFalse(result["running"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mcp_headless.py
+++ b/tests/test_mcp_headless.py
@@ -3,7 +3,7 @@
 
 import tempfile
 import unittest
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from unittest.mock import Mock, patch
 
 from abaqus_codex.mcp_headless import (
@@ -36,24 +36,29 @@ def offline_result():
 class HeadlessCommandTests(unittest.TestCase):
     """确认不同平台的固定命令参数正确。"""
 
-    @patch("abaqus_codex.mcp_headless.os.name", "nt")
     def test_windows_batch_uses_cmd(self):
         """Windows 批处理必须交给 cmd.exe，但不拼接用户 shell 文本。"""
 
         with patch.dict("os.environ", {"COMSPEC": r"C:\Windows\System32\cmd.exe"}):
             args = _abaqus_arguments(
-                Path(r"C:\SIMULIA\Commands\abaqus.bat"),
-                Path(r"C:\Users\User\.abaqus-mcp\mcp_headless_bridge.py"),
+                PureWindowsPath(r"C:\SIMULIA\Commands\abaqus.bat"),
+                PureWindowsPath(
+                    r"C:\Users\User\.abaqus-mcp\mcp_headless_bridge.py"
+                ),
+                system_name="nt",
             )
         self.assertEqual(args[1:3], ["/d", "/c"])
         self.assertEqual(args[-2], "cae")
         self.assertTrue(args[-1].startswith("noGUI="))
 
-    @patch("abaqus_codex.mcp_headless.os.name", "posix")
     def test_regular_executable_uses_direct_arguments(self):
         """非批处理命令应直接传递参数列表。"""
 
-        args = _abaqus_arguments(Path("/opt/abaqus"), Path("/tmp/bridge.py"))
+        args = _abaqus_arguments(
+            PurePosixPath("/opt/abaqus"),
+            PurePosixPath("/tmp/bridge.py"),
+            system_name="posix",
+        )
         self.assertEqual(args, ["/opt/abaqus", "cae", "noGUI=/tmp/bridge.py"])
 
 


### PR DESCRIPTION
## 问题

部分 Abaqus 2021 会话中，Background 模式不能稳定轮询；Cooperative/Blocking 模式又会占用 CAE 图形主线程，表现为进度条左右移动、鼠标持续转圈。

另外，Windows + Python 3.13 使用 `os.kill(pid, 0)` 检查 PID 时可能抛出底层兼容异常。

## 功能

- 新增 `mcp-headless start/status/stop`
- 使用隐藏的独立 `Abaqus cae noGUI` 许可证会话运行稳定阻塞桥接
- 不打开任何私人 `.cae` 文件，默认提供空白 `Model-1`
- Windows 使用 `CREATE_BREAKAWAY_FROM_JOB` 保持后台进程，不弹控制台窗口
- 同时记录启动器 PID 与 Abaqus 内核 PID
- 停止命令只发送 `stop.flag`，不强制结束求解进程
- Windows PID 检查改用只读 `OpenProcess`
- 增加中文排障文档

## 验证

- 79 项离线测试全部通过
- wheel 构建成功并包含 `mcp_headless.py`
- Windows 11 + Abaqus 2021 真实隐藏启动成功
- 真实 `ping` 返回 `pong (v4.0.0)`
- 真实 `get_model_info` 读取空白 `Model-1`
- 等待后心跳持续在线
- 优雅停止成功，随后重新启动成功

## 使用

```powershell
.\.venv\Scripts\python.exe -m abaqus_codex mcp-headless start
.\.venv\Scripts\python.exe -m abaqus_codex mcp-headless status
.\.venv\Scripts\python.exe -m abaqus_codex mcp-headless stop
```

该模式会占用一个独立 Abaqus/CAE 许可证会话。