### PR TITLE
v0.2.2-alpha：新增一键 Windows 安装包

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@
 
 尚无。
 
+## [0.2.2-alpha] - 2026-08-31
+
+### 新增
+
+- 提供普通用户可直接双击的自包含 Windows x64 Setup，内置隔离的官方 Python 3.12.10 运行时，不再要求预装 Python、Git、下载源码或运行 PowerShell；
+- 安装到当前用户目录并提供明确命名的 `AbaqusCodexAssistant.exe` 应用入口、开始菜单和桌面快捷方式，可从 Windows“设置 → 应用”卸载；
+- 安装版把只读程序资源与 `%LOCALAPPDATA%\AbaqusCodexAssistant` 用户数据分开，并支持自定义 `CODEX_HOME`；
+- 新增可恢复的 `integration-setup` / `integration-remove`，只管理本项目 Skill 和经实时版本校验的 Abaqus 2021 安全插件，保留旧目录备份与用户修改；
+- 构建过程固定校验官方 Python ZIP 的 SHA-256，生成 Setup 同步校验文件，并加入隔离安装、启动和卸载回归验证。
+
+### 安全边界
+
+- Setup 不包含 Abaqus、许可证、Codex 账号、Cookie、API Key、CAE、ODB 或论文数据库会话；abqpy 与 MCP 继续在环境体检后由用户单独确认；
+- 未购买代码签名证书，本 Alpha 安装包可能显示 Windows“未知发布者”，官方 Release 同时公布 SHA-256 供核验。
+
 ## [0.2.1-alpha] - 2026-08-31
 
 ### 修复

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ title: "Abaqus Codex Assistant"
 type: software
 authors:
   - family-names: "1721780603-cell"
-version: "0.2.1-alpha"
+version: "0.2.2-alpha"
 date-released: 2026-08-31
 license: MIT
 repository-code: "https://github.com/1721780603-cell/abaqus-codex-assistant"

--- a/README.md
+++ b/README.md
@@ -46,18 +46,35 @@
 ## 运行要求
 
 - Windows 10/11；
-- Python 3.10 或更高版本；
+- 普通用户使用 EXE 安装版时，无需另装 Python 或 Git；安装包自带项目 Python；
+- 只有从源码开发或运行源码备用安装时，才需要 Python 3.10 或更高版本；Git 只在克隆、贡献或 GitHub 工作流中需要；
 - 安装和打开核心助手不要求先装 Abaqus；创建或求解真实模型时，必须已有合法安装、可用许可证和明确版本的 Abaqus；
-- Git 仅为源码开发或 GitHub 工作流所需；
+- Codex 智能模式使用用户本人安装并登录的 Codex；应用不会附带账号、共享额度或复制登录凭据；
 - Abaqus 2021–2025 使用与年份严格匹配的 `abqpy==<年份>.*`，例如 Abaqus 2024 使用 `abqpy==2024.*`；Abaqus 2026 自动流程当前禁用；
 - Codex 和 Abaqus MCP 仅为智能模式所需。
 - 三维移动载荷示例还需要与 Abaqus 匹配的 Visual Studio 和 Intel Fortran Classic。
 
 项目不分发 Abaqus，也不绕过许可证。
 
-## 两条安装路径
+## 安装方式（普通用户首选 EXE）
 
-### 路径一：只安装 Codex Skill
+### 首选：双击 EXE 安装完整应用
+
+普通用户从 [GitHub Releases](https://github.com/1721780603-cell/abaqus-codex-assistant/releases) 下载 `AbaqusCodexAssistant-Setup-<版本>-x64.exe`，双击后按提示安装即可。不需要下载源码、手工创建虚拟环境、运行 PowerShell，也不需要预装 Python 或 Git。
+
+安装完成后：
+
+- 桌面快捷方式直接启动中文建模助手 `AbaqusCodexAssistant.exe`；
+- 应用安装在 `%LOCALAPPDATA%\Programs\AbaqusCodexAssistant`；
+- 自带的项目 Python 位于 `%LOCALAPPDATA%\Programs\AbaqusCodexAssistant\runtime\python.exe`；
+- Codex Skill 随应用安装，但不会复制任何账号、API Key、Cookie 或会话；
+- Abaqus、合法许可证以及用户本人的 Codex 安装和登录仍需自行准备。
+
+首次打开先运行“环境体检”。abqpy 和 MCP 默认不静默安装：体检确认 Abaqus 年份后，助手才会分别说明严格匹配的 abqpy 版本以及 MCP 对用户级配置的影响，并在用户明确同意后处理。基础建模不要求 MCP。
+
+`AbaqusCodexAssistant.exe` 是用户直接使用的应用入口；同目录内的私有 Python 只是程序内部运行零件。Abaqus 自带 Python 仍只负责对应年份的 Abaqus 建模与求解，两者不会要求用户手工切换。
+
+### 可选：只安装 Codex Skill
 
 这条路径只安装对话向导，适合体验逐步提问、环境解释和安装引导。**只装 Skill 不等于安装完整应用**：它不会安装桌面助手、项目 Python 环境、Abaqus 插件、abqpy 或 MCP，也不能单独执行建模。
 
@@ -75,23 +92,23 @@
 
 体检完成后，向导会一次只询问一组建模参数。它把个人配置保存在 `configs/user_models/`，先运行离线校验，并在得到明确确认后才启动 Abaqus。Skill 不包含 Abaqus，也不会绕过许可证或自动上传模型文件。电脑上尚无完整应用时，向导只会引导用户下载 Release，不会把 Skill 误报成已经具备建模能力。
 
-### 路径二：安装完整桌面应用
+### 开发或备用：从源码安装
 
-从 GitHub Releases 下载并完整解压项目后，可先查看不会写入电脑的安装计划：
+只有参与开发、排查打包问题或 EXE 暂时无法使用时，才从 GitHub Releases 下载完整源码包并整体解压。不能只下载 `installer/install.ps1`。可先查看不会写入电脑的安装计划：
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File .\installer\install.ps1 -WhatIf
 ```
 
-可以直接运行统一安装，不要求先检测到 Abaqus。安装器会先把桌面助手安装到当前用户的 `%LOCALAPPDATA%\Programs\AbaqusCodexAssistant`，同时安装 Codex Skill 并创建桌面快捷方式；历史记录和快照仍放在独立的 `%LOCALAPPDATA%\AbaqusCodexAssistant` 数据目录。随后再检测 Abaqus，只有可用的 Abaqus 2021 会自动安装当前已完成真机验证的安全修改插件：
+源码备用安装需要本机已有 Python 3.10 或更高版本，但不要求先检测到 Abaqus。安装器会先安装桌面助手和 Skill，再检测 Abaqus：
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File .\installer\install.ps1
 ```
 
-MCP 和 abqpy 会联网，因此默认不安装；用户明确需要时才增加 `-InstallMcp` 或 `-InstallAbqpy`，它们仍会按各自的版本兼容规则检查。非 2021 版本可以安装核心助手和 Skill，但不会被误报为已能安全修改模型。安装器不会复制维护者或用户的 Codex 登录、API Key、Cookie、许可证或论文数据库会话。升级、修复和卸载说明见 [Windows 统一安装向导](installer/README.md)。
+MCP 和 abqpy 会联网，因此默认不安装；用户明确需要时才增加 `-InstallMcp` 或 `-InstallAbqpy`，它们仍会按各自的版本兼容规则检查。升级、修复和卸载说明见 [Windows 统一安装向导](installer/README.md)。
 
-已经单独安装过旧版 Skill 时，不要手工覆盖目录。下载新的完整 Release 后运行下面的修复安装；安装器会先备份旧 Skill 和旧应用目录：
+已经单独安装过旧版 Skill 时，不要手工覆盖目录。普通用户直接运行新版 EXE 升级；源码备用模式可运行下面的修复安装：
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File .\installer\install.ps1 -Mode Repair
@@ -99,28 +116,33 @@ powershell -ExecutionPolicy Bypass -File .\installer\install.ps1 -Mode Repair
 
 ## 快速开始
 
+### 普通用户：从桌面快捷方式启动
+
+运行 EXE 安装器后，双击桌面的 “Abaqus Codex Assistant”。第一次先打开“环境体检”，确认应用显示的项目 Python、Abaqus 路径和年份符合当前电脑；然后再选择基础建模或 Codex 智能模式。普通用户通常不需要手工运行下面的 Python 命令。
+
 ### 开发者：从源码运行
 
 以下命令在 PowerShell 的项目根目录运行。先安装项目并进行只读体检，不要在尚未确认 Abaqus 年份时直接安装最新版 abqpy：
 
 ```powershell
 py -m venv .venv
-.\.venv\Scripts\python.exe -m pip install --upgrade pip
-.\.venv\Scripts\python.exe -m pip install -e .
-.\.venv\Scripts\python.exe -m abaqus_codex onboard
+$ProjectPython = (Resolve-Path ".\.venv\Scripts\python.exe").Path
+& $ProjectPython -m pip install --upgrade pip
+& $ProjectPython -m pip install -e .
+& $ProjectPython -m abaqus_codex onboard
 ```
 
 先在不连接 Abaqus 的情况下打开中文助手模拟界面：
 
 ```powershell
-.\.venv\Scripts\python.exe -m abaqus_codex assistant --mock
+& $ProjectPython -m abaqus_codex assistant --mock
 ```
 
 真实使用前，先演练并安装安全材料动作插件：
 
 ```powershell
-.\.venv\Scripts\python.exe -m abaqus_codex assistant-setup --dry-run
-.\.venv\Scripts\python.exe -m abaqus_codex assistant-setup --yes
+& $ProjectPython -m abaqus_codex assistant-setup --dry-run
+& $ProjectPython -m abaqus_codex assistant-setup --yes
 ```
 
 关闭并重新打开 Abaqus/CAE 2021，打开一个已经保存过的 CAE；如需刷新完整对象名称摘要，再点击：
@@ -132,7 +154,7 @@ Plug-ins → Abaqus Codex Assistant → Refresh Read-Only Snapshot
 再启动桌面助手：
 
 ```powershell
-.\.venv\Scripts\python.exe -m abaqus_codex assistant
+& $ProjectPython -m abaqus_codex assistant
 ```
 
 Windows 用户也可以直接双击项目根目录中的 `启动中文建模助手.cmd`。该启动器只使用项目自己的虚拟环境；如果环境尚未安装，会显示明确提示而不会改用未知的系统 Python。为兼容不同 Windows 代码页，启动文件本身只使用 ASCII 字符，中文操作说明保留在本文档和应用界面中。可以为这个文件创建桌面快捷方式，移动项目后需要重新创建快捷方式。
@@ -141,11 +163,25 @@ Windows 用户也可以直接双击项目根目录中的 `启动中文建模助�
 
 初学者不需要背诵十条固定句式：每一步成功后，输入框会自动填入下一条命令；“查看十步指令”可随时查看每一步目的和完整句式。“操作记录”会把以后生成的计划、执行成功或失败结果保存到本机，关闭助手后仍可回看；记录不包含完整路径、凭据或模型文件。
 
+下面的高级命令同时适用于 EXE 安装版和源码版。先确定当前模式的项目 Python，并确认文件存在；不要从别人的电脑复制绝对路径，也不要改用未知的系统 Python：
+
+```powershell
+# EXE 安装版
+$ProjectPython = [System.IO.Path]::GetFullPath("$env:LOCALAPPDATA\Programs\AbaqusCodexAssistant\runtime\python.exe")
+
+# 源码版请改用这一行
+# $ProjectPython = (Resolve-Path ".\.venv\Scripts\python.exe").Path
+
+Test-Path -LiteralPath $ProjectPython
+```
+
+只有 `Test-Path` 返回 `True` 时才继续。应用或 Skill 自动执行时也必须使用检测到的项目 Python 绝对路径。
+
 体检显示的 Abaqus 命令路径符合预期、且年份为当前允许继续的 2021–2025 后，再让项目安装同年份的 abqpy。下面的命令会联网修改当前项目 Python，因此只在核对安装计划并同意后使用 `--yes`：
 
 ```powershell
-.\.venv\Scripts\python.exe -m abaqus_codex abqpy-setup --yes
-.\.venv\Scripts\python.exe -m abaqus_codex onboard
+& $ProjectPython -m abaqus_codex abqpy-setup --yes
+& $ProjectPython -m abaqus_codex onboard
 ```
 
 安装器始终生成严格年份规格：Abaqus 2021 对应 `abqpy==2021.*`，Abaqus 2024 对应 `abqpy==2024.*`，不会安装不带年份限制的最新版。
@@ -159,8 +195,8 @@ Windows 用户也可以直接双击项目根目录中的 `启动中文建模助�
 运行首次启动体检；普通输出适合人阅读，JSON 输出适合 Skill 判断下一步：
 
 ```powershell
-.\.venv\Scripts\python.exe -m abaqus_codex onboard
-.\.venv\Scripts\python.exe -m abaqus_codex onboard --json
+& $ProjectPython -m abaqus_codex onboard
+& $ProjectPython -m abaqus_codex onboard --json
 ```
 
 这两个命令只读取状态，不会安装软件、修改配置或替用户登录。ScienceDirect 状态会保持为“需要用户确认”，不会根据浏览器 Cookie 猜测登录成功。
@@ -168,19 +204,19 @@ Windows 用户也可以直接双击项目根目录中的 `启动中文建模助�
 只检查 Abaqus、abqpy 和 MCP 核心环境：
 
 ```powershell
-.\.venv\Scripts\python.exe -m abaqus_codex doctor
+& $ProjectPython -m abaqus_codex doctor
 ```
 
 如需智能模式，在阅读安全说明后安装或注册 MCP：
 
 ```powershell
-.\.venv\Scripts\python.exe -m abaqus_codex mcp-setup --yes
+& $ProjectPython -m abaqus_codex mcp-setup --yes
 ```
 
 已有 MCP 点击后一直转圈时，安装防卡启动器并更新注册：
 
 ```powershell
-.\.venv\Scripts\python.exe -m abaqus_codex mcp-setup --repair --yes
+& $ProjectPython -m abaqus_codex mcp-setup --repair --yes
 ```
 
 详细原因和排查步骤见 [Abaqus MCP 一直转圈排查](docs/mcp-troubleshooting.md)。
@@ -188,9 +224,9 @@ Windows 用户也可以直接双击项目根目录中的 `启动中文建模助�
 如果 GUI 模式仍导致进度条和鼠标转圈，使用无界面后台桥接：
 
 ```powershell
-.\.venv\Scripts\python.exe -m abaqus_codex mcp-headless start
-.\.venv\Scripts\python.exe -m abaqus_codex mcp-headless status
-.\.venv\Scripts\python.exe -m abaqus_codex mcp-headless stop
+& $ProjectPython -m abaqus_codex mcp-headless start
+& $ProjectPython -m abaqus_codex mcp-headless status
+& $ProjectPython -m abaqus_codex mcp-headless stop
 ```
 
 该模式使用独立 Abaqus/CAE 许可证会话，不显示操作界面，也不会预先打开任何私人模型。
@@ -198,19 +234,19 @@ Windows 用户也可以直接双击项目根目录中的 `启动中文建模助�
 保存使用场景：
 
 ```powershell
-.\.venv\Scripts\python.exe -m abaqus_codex configure --scenario learning
+& $ProjectPython -m abaqus_codex configure --scenario learning
 ```
 
 检查本地 AI（可选）：
 
 ```powershell
-.\.venv\Scripts\python.exe -m abaqus_codex local-ai doctor
+& $ProjectPython -m abaqus_codex local-ai doctor
 ```
 
 用 Ollama 生成一份矩形板配置；程序会先显示完整 JSON，确认后才保存：
 
 ```powershell
-.\.venv\Scripts\python.exe -m abaqus_codex local-ai generate `
+& $ProjectPython -m abaqus_codex local-ai generate `
   --provider ollama `
   --model "你的本机模型名称" `
   --prompt "建立长 200 mm、高 100 mm、厚 2 mm 的矩形板，右边拉伸 0.2 mm。"
@@ -221,7 +257,7 @@ Windows 用户也可以直接双击项目根目录中的 `启动中文建模助�
 在启动 Abaqus 前单独检查任意受支持的配置：
 
 ```powershell
-.\.venv\Scripts\python.exe -m abaqus_codex validate --config .\configs\rectangle_tension.json
+& $ProjectPython -m abaqus_codex validate --config .\configs\rectangle_tension.json
 ```
 
 命令只读取并规范化 JSON，不占用 Abaqus 许可证。
@@ -229,31 +265,31 @@ Windows 用户也可以直接双击项目根目录中的 `启动中文建模助�
 运行二维矩形板拉伸示例：
 
 ```powershell
-.\.venv\Scripts\python.exe -m abaqus_codex run
+& $ProjectPython -m abaqus_codex run
 ```
 
 运行二维中心圆孔板拉伸示例：
 
 ```powershell
-.\.venv\Scripts\python.exe -m abaqus_codex run --config .\configs\plate_with_hole_tension.json
+& $ProjectPython -m abaqus_codex run --config .\configs\plate_with_hole_tension.json
 ```
 
 运行二维悬臂梁均布载荷弯曲示例：
 
 ```powershell
-.\.venv\Scripts\python.exe -m abaqus_codex run --config .\configs\cantilever_bending.json
+& $ProjectPython -m abaqus_codex run --config .\configs\cantilever_bending.json
 ```
 
 运行二维方板双向拉伸示例：
 
 ```powershell
-.\.venv\Scripts\python.exe -m abaqus_codex run --config .\configs\biaxial_tension.json
+& $ProjectPython -m abaqus_codex run --config .\configs\biaxial_tension.json
 ```
 
 运行三维路面单轮移动载荷示例：
 
 ```powershell
-.\.venv\Scripts\python.exe -m abaqus_codex run --config .\configs\moving_load_road.json
+& $ProjectPython -m abaqus_codex run --config .\configs\moving_load_road.json
 ```
 
 移动载荷会编译项目生成的 Fortran DLOAD。首次使用前请阅读[移动载荷入门说明](docs/moving-load-dload.md)。
@@ -342,12 +378,12 @@ abaqus-codex-assistant/
 开发环境应安装测试依赖：
 
 ```powershell
-.\.venv\Scripts\python.exe -m pip install -e ".[test]"
+& $ProjectPython -m pip install -e ".[test]"
 ```
 
 ```powershell
 $env:PYTHONPATH = (Join-Path (Get-Location) "src")
-.\.venv\Scripts\python.exe -m unittest discover -s tests -v
+& $ProjectPython -m unittest discover -s tests -v
 ```
 
 GitHub Actions 只运行不依赖 Abaqus 许可证的测试。真实求解必须在已安装 Abaqus 的电脑上运行。

--- a/abaqus_plugins/ai_modeling_assistant/ai_modeling_assistant_plugin.py
+++ b/abaqus_plugins/ai_modeling_assistant/ai_modeling_assistant_plugin.py
@@ -30,7 +30,7 @@ toolset.registerGuiMenuButton(
     object=ChineseModelingAssistantForm(toolset),
     buttonText=u"AI 中文建模助手...",
     applicableModules=ALL,
-    version="0.2.1",
+    version="0.2.2",
     author="Abaqus Codex Assistant Contributors",
     description=(
         u"Abaqus 2021 中文建模助手界面预览。"

--- a/abaqus_plugins/safe_material_action/safe_material_action_plugin.py
+++ b/abaqus_plugins/safe_material_action/safe_material_action_plugin.py
@@ -44,7 +44,7 @@ def _write_status():
     temporary = path + ".tmp"
     value = {
         "schema": STATUS_SCHEMA,
-        "version": "0.2.1",
+        "version": "0.2.2",
         "abaqus_release": "2021",
         "status": "running",
         "timestamp": time.time(),
@@ -163,7 +163,7 @@ toolset.registerGuiMenuButton(
     buttonText="Abaqus Codex Assistant|Process One Pending Safe Action",
     messageId=SafeActionPump.ID_MANUAL,
     applicableModules=ALL,
-    version="0.2.1",
+    version="0.2.2",
     author="1721780603-cell and contributors",
     description="Process one validated material action in the GUI event loop.",
 )

--- a/installer/README.md
+++ b/installer/README.md
@@ -1,4 +1,30 @@
-# Windows 统一安装向导 v1
+# Windows 安装与单文件 Setup
+
+## 推荐给普通用户：双击单文件 Setup
+
+普通用户只需要从 GitHub Release 下载 `AbaqusCodexAssistant-Setup-<版本>-x64.exe`，双击并按向导完成安装。该 Setup 已内置官方 Python 3.12.10 x64 完整运行时，不要求用户预装 Python，也不会在安装时下载 Python 或项目代码。它会：
+
+- 按当前用户安装到 `%LOCALAPPDATA%\Programs\AbaqusCodexAssistant`，不要求管理员权限；
+- 安装并创建 `AbaqusCodexAssistant.exe` 的开始菜单和可选桌面快捷方式，之后直接双击应用使用；
+- 首次安装调用 `integration-setup --yes`，只为当前用户安装或修复本项目拥有的 Skill 与受支持的 Abaqus 集成；
+- 从“设置 → 应用”正常卸载，卸载前调用 `integration-remove --yes` 清理本项目拥有的集成；
+- 保留 `%LOCALAPPDATA%\AbaqusCodexAssistant` 中的用户历史、快照和模型工作数据。
+
+Setup 不包含 Abaqus、Codex、许可证、账号、Cookie、API Key 或论文数据库会话。需要 AI 对话时，用户仍须自行安装并登录 Codex；需要真实求解时，仍须自行合法安装 Abaqus 并拥有可用许可证。未购买代码签名证书前，Windows 可能显示“未知发布者”，请只从本项目官方 Release 下载，并用同页 `.sha256` 文件校验。
+
+## 维护者：构建单文件 Setup
+
+构建机需要 Windows、Inno Setup 6.7.3 和官方 Python 3.12.10 full amd64 ZIP。构建脚本固定校验 Python ZIP 与 Inno 编译器的 SHA256，并验证 Inno 的 Pyrsys B.V. 数字签名，不接受被替换的构建工具或运行时：
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\installer\build_windows_setup.ps1 `
+  -PythonArchive C:\path\python-3.12.10-amd64.zip `
+  -InnoCompiler "C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
+```
+
+省略 `-PythonArchive` 时，只有维护者构建过程会从 python.org 下载固定版本并校验 SHA256；终端用户运行生成的 Setup 时不会联网下载运行时。省略 `-InnoCompiler` 时会检查 `INNO_ISCC` 和 Inno Setup 6 的标准安装位置。输出位于 `build\windows-setup\output`，且只包含一个 x64 Setup 与对应的 `.sha256` 文件。构建脚本只会清理 `build\windows-setup` 下的专用 staging/output 目录。
+
+## 源码 PowerShell 安装（兼容路径）
 
 该向导先把同一个 GitHub Release 中的桌面助手安装到 `%LOCALAPPDATA%\Programs\AbaqusCodexAssistant`，并安装 Codex Skill，然后才检测 Abaqus。没有安装 Abaqus 也不会阻止核心程序安装；当前仅在检测到可用的 Abaqus 2021 后自动安装已验证的安全修改插件。历史、快照和动作队列继续保存在独立的数据目录 `%LOCALAPPDATA%\AbaqusCodexAssistant`。安装器不包含 Abaqus、Codex、许可证、账号、Cookie、API Key 或论文数据库会话。
 
@@ -53,7 +79,7 @@ powershell -ExecutionPolicy Bypass -File .\installer\uninstall.ps1
 
 - 核心程序和 Skill 先安装，随后才只读检测 Abaqus；未检测到 Abaqus 时保留核心安装并给出配置提示；
 - 维护者只在 Abaqus 2021 上完成安全修改插件的真机验证；其他版本先安装核心助手和 Skill，但不会自动启用模型修改；
-- v1 不内置 Python 运行时；后续正式 EXE 再评估自包含运行时；
+- 源码 PowerShell 安装路径不内置 Python；推荐的单文件 Setup 已内置 Python 3.12.10 x64 运行时；
 - MCP、abqpy 需要联网，所以必须由用户主动选择；
 - Abaqus 2021 安装了安全插件后必须重启 Abaqus/CAE 和 Codex；
 - 未购买代码签名证书前，Windows 可能显示未知发布者提示。

--- a/installer/build_windows_setup.ps1
+++ b/installer/build_windows_setup.ps1
@@ -1,0 +1,350 @@
+[CmdletBinding()]
+param(
+    [string]$PythonArchive,
+    [string]$InnoCompiler
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$PythonVersion = "3.12.10"
+$PythonArchiveName = "python-3.12.10-amd64.zip"
+$PythonArchiveUri = "https://www.python.org/ftp/python/$PythonVersion/$PythonArchiveName"
+$PythonArchiveSha256 = "8649692DE846C56A7189D6DAE5C322AB20DEB1B5908B6F39426B62A36F39415D"
+$InnoCompilerSha256 = "0A8757031B33777E4C9CBFFEE40F11A5062B36D25CBE144C1DB73B6102B80AD7"
+$InnoSignerSubjectNeedle = "Pyrsys B.V."
+
+function Stop-Build([string]$Message) {
+    throw "Windows setup build: $Message"
+}
+
+function Get-FullPath([string]$Path) {
+    return [System.IO.Path]::GetFullPath($Path)
+}
+
+$projectRoot = Get-FullPath (Split-Path -Parent $PSScriptRoot)
+$buildRoot = Get-FullPath (Join-Path $projectRoot "build\windows-setup")
+$downloadRoot = Get-FullPath (Join-Path $buildRoot "downloads")
+$sourceRoot = Get-FullPath (Join-Path $buildRoot "source")
+$sourceArchive = Get-FullPath (Join-Path $buildRoot "source.zip")
+$stagingRoot = Get-FullPath (Join-Path $buildRoot "staging")
+$runtimeRoot = Get-FullPath (Join-Path $stagingRoot "runtime")
+$outputRoot = Get-FullPath (Join-Path $buildRoot "output")
+$innoScript = Get-FullPath (Join-Path $PSScriptRoot "windows_setup.iss")
+
+$pyprojectText = [System.IO.File]::ReadAllText((Join-Path $projectRoot "pyproject.toml"))
+$packageMatch = [regex]::Match(
+    $pyprojectText,
+    '(?m)^version\s*=\s*"(?<version>[^"]+)"\s*$'
+)
+if (-not $packageMatch.Success) {
+    Stop-Build "pyproject.toml does not contain one package version."
+}
+$PackageVersion = $packageMatch.Groups["version"].Value
+$pep440Match = [regex]::Match(
+    $PackageVersion,
+    '^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)a(?<alpha>\d+)$'
+)
+if (-not $pep440Match.Success) {
+    Stop-Build "the package version is not the expected PEP 440 alpha form: $PackageVersion"
+}
+$AppVersion = "{0}.{1}.{2}-alpha" -f @(
+    $pep440Match.Groups["major"].Value,
+    $pep440Match.Groups["minor"].Value,
+    $pep440Match.Groups["patch"].Value
+)
+$ReleaseSerial = "{0:D4}{1:D4}{2:D4}1{3:D4}" -f @(
+    [int]$pep440Match.Groups["major"].Value,
+    [int]$pep440Match.Groups["minor"].Value,
+    [int]$pep440Match.Groups["patch"].Value,
+    [int]$pep440Match.Groups["alpha"].Value
+)
+$packageInitText = [System.IO.File]::ReadAllText(
+    (Join-Path $projectRoot "src\abaqus_codex\__init__.py")
+)
+$citationText = [System.IO.File]::ReadAllText((Join-Path $projectRoot "CITATION.cff"))
+if ($packageInitText -notmatch ('__version__\s*=\s*"' + [regex]::Escape($PackageVersion) + '"')) {
+    Stop-Build "src/abaqus_codex/__init__.py does not match pyproject.toml."
+}
+if ($citationText -notmatch ('(?m)^version:\s*"' + [regex]::Escape($AppVersion) + '"\s*$')) {
+    Stop-Build "CITATION.cff does not match the normalized public version $AppVersion."
+}
+$SetupBaseName = "AbaqusCodexAssistant-Setup-$AppVersion-x64"
+
+function Assert-BuildChild([string]$Path) {
+    $full = Get-FullPath $Path
+    $prefix = $buildRoot.TrimEnd("\") + "\"
+    if (-not $full.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+        Stop-Build "refusing to modify a path outside the dedicated build directory: $full"
+    }
+    return $full
+}
+
+function Reset-BuildDirectory([string]$Path) {
+    $safePath = Assert-BuildChild $Path
+    if (Test-Path -LiteralPath $safePath) {
+        Remove-Item -LiteralPath $safePath -Recurse -Force
+    }
+    New-Item -ItemType Directory -Path $safePath -Force | Out-Null
+}
+
+function Copy-RequiredDirectory([string]$Name) {
+    $source = Join-Path $sourceRoot $Name
+    if (-not (Test-Path -LiteralPath $source -PathType Container)) {
+        Stop-Build "release payload is missing directory: $Name"
+    }
+    Copy-Item -LiteralPath $source -Destination (Join-Path $stagingRoot $Name) -Recurse
+}
+
+function Copy-RequiredFile([string]$Name) {
+    $source = Join-Path $sourceRoot $Name
+    if (-not (Test-Path -LiteralPath $source -PathType Leaf)) {
+        Stop-Build "release payload is missing file: $Name"
+    }
+    Copy-Item -LiteralPath $source -Destination (Join-Path $stagingRoot $Name)
+}
+
+if ($env:OS -ne "Windows_NT") {
+    Stop-Build "this build script supports Windows only."
+}
+if (-not (Test-Path -LiteralPath $innoScript -PathType Leaf)) {
+    Stop-Build "Inno Setup source was not found: $innoScript"
+}
+
+New-Item -ItemType Directory -Path $buildRoot -Force | Out-Null
+New-Item -ItemType Directory -Path $downloadRoot -Force | Out-Null
+
+if ([string]::IsNullOrWhiteSpace($PythonArchive)) {
+    $PythonArchive = Join-Path $downloadRoot $PythonArchiveName
+    if (-not (Test-Path -LiteralPath $PythonArchive -PathType Leaf)) {
+        Write-Host "Downloading the official Python $PythonVersion x64 runtime for the maintainer build..."
+        Invoke-WebRequest -Uri $PythonArchiveUri -OutFile $PythonArchive -UseBasicParsing
+    }
+}
+elseif (-not (Test-Path -LiteralPath $PythonArchive -PathType Leaf)) {
+    Stop-Build "Python archive was not found: $PythonArchive"
+}
+$PythonArchive = Get-FullPath (Resolve-Path -LiteralPath $PythonArchive).Path
+$actualPythonHash = (Get-FileHash -LiteralPath $PythonArchive -Algorithm SHA256).Hash.ToUpperInvariant()
+if ($actualPythonHash -ne $PythonArchiveSha256) {
+    Stop-Build "Python archive SHA256 mismatch. Expected $PythonArchiveSha256 but received $actualPythonHash."
+}
+
+if ([string]::IsNullOrWhiteSpace($InnoCompiler)) {
+    $candidates = @()
+    if (-not [string]::IsNullOrWhiteSpace($env:INNO_ISCC)) {
+        $candidates += $env:INNO_ISCC
+    }
+    if (-not [string]::IsNullOrWhiteSpace(${env:ProgramFiles(x86)})) {
+        $candidates += Join-Path ${env:ProgramFiles(x86)} "Inno Setup 6\ISCC.exe"
+    }
+    if (-not [string]::IsNullOrWhiteSpace($env:ProgramFiles)) {
+        $candidates += Join-Path $env:ProgramFiles "Inno Setup 6\ISCC.exe"
+    }
+    foreach ($candidate in $candidates) {
+        if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+            $InnoCompiler = $candidate
+            break
+        }
+    }
+}
+if ([string]::IsNullOrWhiteSpace($InnoCompiler) -or -not (Test-Path -LiteralPath $InnoCompiler -PathType Leaf)) {
+    Stop-Build "ISCC.exe was not found. Install Inno Setup 6 or pass -InnoCompiler."
+}
+$InnoCompiler = Get-FullPath (Resolve-Path -LiteralPath $InnoCompiler).Path
+$actualInnoHash = (Get-FileHash -LiteralPath $InnoCompiler -Algorithm SHA256).Hash.ToUpperInvariant()
+if ($actualInnoHash -ne $InnoCompilerSha256) {
+    Stop-Build "ISCC.exe SHA256 mismatch. Expected $InnoCompilerSha256 but received $actualInnoHash."
+}
+$innoSignature = Get-AuthenticodeSignature -LiteralPath $InnoCompiler
+$innoSigner = ""
+if ($null -ne $innoSignature.SignerCertificate) {
+    $innoSigner = $innoSignature.SignerCertificate.Subject
+}
+if (
+    $innoSignature.Status -ne [System.Management.Automation.SignatureStatus]::Valid -or
+    $innoSigner.IndexOf($InnoSignerSubjectNeedle, [System.StringComparison]::OrdinalIgnoreCase) -lt 0
+) {
+    Stop-Build "ISCC.exe does not have the expected valid Pyrsys B.V. signature."
+}
+
+Reset-BuildDirectory $stagingRoot
+Reset-BuildDirectory $outputRoot
+Reset-BuildDirectory $sourceRoot
+
+$gitCommand = Get-Command git.exe -ErrorAction SilentlyContinue
+if ($null -eq $gitCommand) {
+    $gitCommand = Get-Command git -ErrorAction SilentlyContinue
+}
+if ($null -eq $gitCommand) {
+    Stop-Build "Git is required on the maintainer build machine to export tracked release files."
+}
+$gitStatus = @(& $gitCommand.Source -C $projectRoot status --porcelain --untracked-files=normal)
+if ($LASTEXITCODE -ne 0) {
+    Stop-Build "Git could not inspect the release worktree."
+}
+if ($gitStatus.Count -ne 0) {
+    Stop-Build "the release worktree is not clean; commit or remove local files before packaging."
+}
+$safeSourceArchive = Assert-BuildChild $sourceArchive
+if (Test-Path -LiteralPath $safeSourceArchive) {
+    Remove-Item -LiteralPath $safeSourceArchive -Force
+}
+& $gitCommand.Source -C $projectRoot archive --format=zip --output=$safeSourceArchive HEAD
+if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $safeSourceArchive -PathType Leaf)) {
+    Stop-Build "Git could not create the tracked source archive."
+}
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+[System.IO.Compression.ZipFile]::ExtractToDirectory($safeSourceArchive, $sourceRoot)
+[System.IO.Compression.ZipFile]::ExtractToDirectory($PythonArchive, $runtimeRoot)
+
+foreach ($requiredRuntimePath in @("python.exe", "pythonw.exe", "Lib", "DLLs")) {
+    if (-not (Test-Path -LiteralPath (Join-Path $runtimeRoot $requiredRuntimePath))) {
+        Stop-Build "Python archive is not the required full x64 distribution: $requiredRuntimePath"
+    }
+}
+
+# Build a real desktop launcher. Directly double-clicking this EXE always
+# starts the fixed private runtime command; it is not a renamed pythonw.exe.
+$launcherSource = Join-Path $sourceRoot "installer\windows_launcher.cs"
+if (-not (Test-Path -LiteralPath $launcherSource -PathType Leaf)) {
+    Stop-Build "release payload is missing installer/windows_launcher.cs."
+}
+$appExecutable = Join-Path $stagingRoot "AbaqusCodexAssistant.exe"
+$csharpCandidates = @(
+    (Join-Path $env:WINDIR "Microsoft.NET\Framework64\v4.0.30319\csc.exe"),
+    (Join-Path $env:WINDIR "Microsoft.NET\Framework\v4.0.30319\csc.exe")
+)
+$csharpCompiler = $null
+foreach ($candidate in $csharpCandidates) {
+    if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+        $csharpCompiler = $candidate
+        break
+    }
+}
+if ($null -eq $csharpCompiler) {
+    Stop-Build "the signed Microsoft .NET Framework C# compiler was not found."
+}
+$csharpSignature = Get-AuthenticodeSignature -LiteralPath $csharpCompiler
+$csharpSigner = ""
+if ($null -ne $csharpSignature.SignerCertificate) {
+    $csharpSigner = $csharpSignature.SignerCertificate.Subject
+}
+if (
+    $csharpSignature.Status -ne [System.Management.Automation.SignatureStatus]::Valid -or
+    $csharpSigner.IndexOf("Microsoft", [System.StringComparison]::OrdinalIgnoreCase) -lt 0
+) {
+    Stop-Build "the C# compiler does not have the expected valid Microsoft signature."
+}
+& $csharpCompiler `
+    /nologo `
+    /target:winexe `
+    /optimize+ `
+    "/out:$appExecutable" `
+    /reference:System.dll `
+    /reference:System.Windows.Forms.dll `
+    $launcherSource
+if ($LASTEXITCODE -ne 0) {
+    Stop-Build "the desktop launcher failed to compile."
+}
+if (-not (Test-Path -LiteralPath $appExecutable -PathType Leaf)) {
+    Stop-Build "the desktop launcher executable was not created."
+}
+
+$pythonDocs = Join-Path $runtimeRoot "Doc"
+if (Test-Path -LiteralPath $pythonDocs) {
+    $safePythonDocs = Assert-BuildChild $pythonDocs
+    Remove-Item -LiteralPath $safePythonDocs -Recurse -Force
+}
+
+$sitePackages = Join-Path $runtimeRoot "Lib\site-packages"
+New-Item -ItemType Directory -Path $sitePackages -Force | Out-Null
+$packageSource = Join-Path $sourceRoot "src\abaqus_codex"
+if (-not (Test-Path -LiteralPath $packageSource -PathType Container)) {
+    Stop-Build "release payload is missing src\abaqus_codex."
+}
+Copy-Item -LiteralPath $packageSource -Destination (Join-Path $sitePackages "abaqus_codex") -Recurse
+
+foreach ($directory in @("configs", "skills", "abaqus_plugins", "docs")) {
+    Copy-RequiredDirectory $directory
+}
+foreach ($file in @(
+    "pyproject.toml",
+    "README.md",
+    "LICENSE",
+    "NOTICE.md",
+    "AUTHORS.md",
+    "SECURITY.md",
+    "CHANGELOG.md",
+    "CITATION.cff"
+)) {
+    Copy-RequiredFile $file
+}
+
+$forbiddenExtensions = @(
+    ".cae", ".odb", ".lck", ".sta", ".msg", ".dat", ".sim", ".res", ".rpy"
+)
+$forbiddenNames = @(
+    ".env", "auth.json", "cookies.json", "credentials.json",
+    "user_profile.json", "local_ai_rectangle.json"
+)
+$payloadRoots = @(
+    (Join-Path $stagingRoot "configs"),
+    (Join-Path $stagingRoot "skills"),
+    (Join-Path $stagingRoot "abaqus_plugins"),
+    (Join-Path $stagingRoot "docs"),
+    (Join-Path $sitePackages "abaqus_codex")
+)
+foreach ($payloadRoot in $payloadRoots) {
+    foreach ($payloadFile in Get-ChildItem -LiteralPath $payloadRoot -Recurse -File) {
+        $lowerName = $payloadFile.Name.ToLowerInvariant()
+        $lowerExtension = $payloadFile.Extension.ToLowerInvariant()
+        if (
+            $forbiddenExtensions -contains $lowerExtension -or
+            $forbiddenNames -contains $lowerName -or
+            $lowerName.StartsWith(".env.")
+        ) {
+            Stop-Build "forbidden private or Abaqus file in release payload: $($payloadFile.FullName)"
+        }
+    }
+}
+
+# Do not ship local bytecode accidentally copied from a maintainer checkout.
+$safeStagingRoot = Assert-BuildChild $stagingRoot
+Get-ChildItem -LiteralPath $safeStagingRoot -Directory -Filter "__pycache__" -Recurse |
+    Remove-Item -Recurse -Force
+Get-ChildItem -LiteralPath $safeStagingRoot -File -Filter "*.pyc" -Recurse |
+    Remove-Item -Force
+
+$runtimePython = Join-Path $runtimeRoot "python.exe"
+& $runtimePython -I -c "import abaqus_codex, tkinter; print('runtime-ok')"
+if ($LASTEXITCODE -ne 0) {
+    Stop-Build "the staged runtime could not import abaqus_codex and tkinter."
+}
+
+$innoArguments = @(
+    "/DStageDir=$stagingRoot",
+    "/DOutputDir=$outputRoot",
+    "/DAppVersion=$AppVersion",
+    "/DReleaseSerial=$ReleaseSerial",
+    "/DSetupBaseName=$SetupBaseName",
+    $innoScript
+)
+& $InnoCompiler @innoArguments
+if ($LASTEXITCODE -ne 0) {
+    Stop-Build "Inno Setup failed with exit code $LASTEXITCODE."
+}
+
+$setups = @(Get-ChildItem -LiteralPath $outputRoot -Filter "*.exe" -File)
+if ($setups.Count -ne 1) {
+    Stop-Build "expected one Setup executable but found $($setups.Count)."
+}
+$setup = $setups[0]
+$setupHash = (Get-FileHash -LiteralPath $setup.FullName -Algorithm SHA256).Hash.ToUpperInvariant()
+$hashPath = "$($setup.FullName).sha256"
+"$setupHash  $($setup.Name)" | Set-Content -LiteralPath $hashPath -Encoding Ascii
+
+Write-Host "Windows setup build completed."
+Write-Host "  Setup:  $($setup.FullName)"
+Write-Host "  SHA256: $hashPath"

--- a/installer/windows_launcher.cs
+++ b/installer/windows_launcher.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Windows.Forms;
+
+internal static class AbaqusCodexAssistantLauncher
+{
+    [STAThread]
+    private static int Main()
+    {
+        string applicationRoot = AppDomain.CurrentDomain.BaseDirectory;
+        string privatePython = Path.Combine(
+            applicationRoot,
+            "runtime",
+            "pythonw.exe"
+        );
+        if (!File.Exists(privatePython))
+        {
+            MessageBox.Show(
+                "The private application runtime is missing. Reinstall Abaqus Codex Assistant.",
+                "Abaqus Codex Assistant",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error
+            );
+            return 1;
+        }
+
+        try
+        {
+            ProcessStartInfo start = new ProcessStartInfo();
+            start.FileName = privatePython;
+            start.Arguments = "-I -m abaqus_codex assistant";
+            start.WorkingDirectory = applicationRoot;
+            start.UseShellExecute = false;
+            start.CreateNoWindow = true;
+            Process.Start(start);
+            return 0;
+        }
+        catch (Exception error)
+        {
+            MessageBox.Show(
+                "Abaqus Codex Assistant could not start. Reinstall the application.\n\n" +
+                error.Message,
+                "Abaqus Codex Assistant",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error
+            );
+            return 1;
+        }
+    }
+}

--- a/installer/windows_setup.iss
+++ b/installer/windows_setup.iss
@@ -1,0 +1,189 @@
+#ifndef StageDir
+  #error StageDir must be supplied by build_windows_setup.ps1
+#endif
+#ifndef OutputDir
+  #error OutputDir must be supplied by build_windows_setup.ps1
+#endif
+#ifndef AppVersion
+  #define AppVersion "0.2.2-alpha"
+#endif
+#ifndef SetupBaseName
+  #define SetupBaseName "AbaqusCodexAssistant-Setup-0.2.2-alpha-x64"
+#endif
+#ifndef ReleaseSerial
+  #define ReleaseSerial "00000002000210001"
+#endif
+
+[Setup]
+AppId={{DCC225A8-53D3-4EC4-9A46-03532CECB5C4}
+AppName=Abaqus Codex Assistant
+AppVersion={#AppVersion}
+AppPublisher=1721780603-cell and contributors
+AppPublisherURL=https://github.com/1721780603-cell/abaqus-codex-assistant
+AppSupportURL=https://github.com/1721780603-cell/abaqus-codex-assistant/issues
+AppUpdatesURL=https://github.com/1721780603-cell/abaqus-codex-assistant/releases
+DefaultDirName={localappdata}\Programs\AbaqusCodexAssistant
+DefaultGroupName=Abaqus Codex Assistant
+DisableProgramGroupPage=yes
+PrivilegesRequired=lowest
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+OutputDir={#OutputDir}
+OutputBaseFilename={#SetupBaseName}
+Compression=lzma2/ultra64
+SolidCompression=yes
+WizardStyle=modern
+CloseApplications=yes
+RestartApplications=no
+UninstallDisplayName=Abaqus Codex Assistant
+LicenseFile={#StageDir}\LICENSE
+SetupLogging=yes
+
+[Registry]
+Root: HKCU; Subkey: "Software\1721780603-cell\AbaqusCodexAssistant"; ValueType: string; ValueName: "ReleaseSerial"; ValueData: "{#ReleaseSerial}"; Flags: uninsdeletekey
+
+[Tasks]
+Name: "desktopicon"; Description: "Create a desktop shortcut"; GroupDescription: "Additional shortcuts:"; Flags: checkedonce
+
+[Files]
+Source: "{#StageDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{autoprograms}\Abaqus Codex Assistant"; Filename: "{app}\AbaqusCodexAssistant.exe"; WorkingDir: "{app}"
+Name: "{autodesktop}\Abaqus Codex Assistant"; Filename: "{app}\AbaqusCodexAssistant.exe"; WorkingDir: "{app}"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\AbaqusCodexAssistant.exe"; WorkingDir: "{app}"; Description: "Launch Abaqus Codex Assistant"; Flags: nowait postinstall skipifsilent
+
+[Code]
+function IsInsideOrSame(const CandidatePath, RootPath: String): Boolean;
+var
+  CandidateValue: String;
+  RootValue: String;
+begin
+  CandidateValue := AddBackslash(ExpandFileName(CandidatePath));
+  RootValue := AddBackslash(ExpandFileName(RootPath));
+  Result := CompareText(Copy(CandidateValue, 1, Length(RootValue)), RootValue) = 0;
+end;
+
+function PathsOverlap(const FirstPath, SecondPath: String): Boolean;
+begin
+  Result := IsInsideOrSame(FirstPath, SecondPath) or
+    IsInsideOrSame(SecondPath, FirstPath);
+end;
+
+function InitializeSetup(): Boolean;
+var
+  InstalledSerial: String;
+begin
+  Result := True;
+  if RegQueryStringValue(
+    HKCU,
+    'Software\1721780603-cell\AbaqusCodexAssistant',
+    'ReleaseSerial',
+    InstalledSerial
+  ) and (CompareText(InstalledSerial, '{#ReleaseSerial}') > 0) then
+  begin
+    MsgBox(
+      'A newer Abaqus Codex Assistant is already installed. Uninstall it before installing this older version.',
+      mbError, MB_OK
+    );
+    Result := False;
+  end;
+end;
+
+function NextButtonClick(CurPageID: Integer): Boolean;
+var
+  CodexHome: String;
+  SkillTarget: String;
+  PluginTarget: String;
+begin
+  Result := True;
+  if CurPageID <> wpSelectDir then
+    Exit;
+  CodexHome := GetEnv('CODEX_HOME');
+  if CodexHome = '' then
+    CodexHome := ExpandConstant('{userprofile}\.codex');
+  SkillTarget := AddBackslash(CodexHome) + 'skills\abaqus-modeling-guide';
+  PluginTarget := ExpandConstant('{userprofile}\abaqus_plugins\safe_material_action');
+  if PathsOverlap(WizardDirValue, SkillTarget) or
+    PathsOverlap(WizardDirValue, PluginTarget) then
+  begin
+    MsgBox(
+      'Choose an application folder outside the Codex Skill and Abaqus plug-in folders.',
+      mbError, MB_OK
+    );
+    Result := False;
+  end;
+end;
+
+function RunIntegration(const Arguments: String; var ResultCode: Integer): Boolean;
+begin
+  Result := Exec(
+    ExpandConstant('{app}\runtime\python.exe'),
+    '-I ' + Arguments,
+    ExpandConstant('{app}'),
+    SW_HIDE,
+    ewWaitUntilTerminated,
+    ResultCode
+  );
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+var
+  ResultCode: Integer;
+  Started: Boolean;
+  DataRoot: String;
+begin
+  if CurStep <> ssPostInstall then
+    Exit;
+  DataRoot := ExpandConstant('{localappdata}\AbaqusCodexAssistant');
+  Started := RunIntegration(
+    '-m abaqus_codex integration-setup --yes --data-root "' + DataRoot + '"',
+    ResultCode
+  );
+  if (not Started) or (ResultCode <> 0) then
+  begin
+    Log(Format('User integration setup failed (started=%d, exit=%d).', [Ord(Started), ResultCode]));
+    if not WizardSilent then
+      MsgBox(
+        'Codex/Abaqus user integration failed, so Setup cannot complete. ' +
+        'No model files were changed.',
+        mbError, MB_OK
+      );
+    RaiseException('Abaqus Codex Assistant user integration failed.');
+  end;
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+var
+  ResultCode: Integer;
+  Started: Boolean;
+  Choice: Integer;
+  DataRoot: String;
+begin
+  if CurUninstallStep <> usUninstall then
+    Exit;
+  while True do
+  begin
+    DataRoot := ExpandConstant('{localappdata}\AbaqusCodexAssistant');
+    Started := RunIntegration(
+      '-m abaqus_codex integration-remove --yes --data-root "' + DataRoot + '"',
+      ResultCode
+    );
+    if Started and (ResultCode = 0) then
+      Exit;
+    Log(Format('User integration removal failed (started=%d, exit=%d).', [Ord(Started), ResultCode]));
+    if UninstallSilent then
+      Abort;
+    Choice := MsgBox(
+      'Codex/Abaqus user integration could not be removed. Retry, abort uninstall, ' +
+      'or choose Ignore to remove only the core application and leave the integration in place.',
+      mbError, MB_ABORTRETRYIGNORE
+    );
+    if Choice = IDIGNORE then
+      Exit;
+    if Choice <> IDRETRY then
+      Abort;
+  end;
+end;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "abaqus-codex-assistant"
-version = "0.2.1a1"
+version = "0.2.2a1"
 description = "面向 Abaqus 初学者的环境检测、建模、求解、结果读取与中文报告工具"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/skills/abaqus-modeling-guide/SKILL.md
+++ b/skills/abaqus-modeling-guide/SKILL.md
@@ -20,18 +20,20 @@ description: 带 Abaqus 初学者逐步完成首次启动检查、选择建模�
 
 ### 1. 找到项目并运行首次向导
 
-先只读定位包含 `pyproject.toml`、`configs/` 和 `src/abaqus_codex/` 的项目根目录，按以下顺序检查：
+先只读定位完整应用或源码项目，并确定后续所有命令使用的“项目 Python 绝对路径”。按以下顺序检查：
 
-1. 统一安装器的默认目录 `%LOCALAPPDATA%\Programs\AbaqusCodexAssistant`；
-2. 当前目录及其父目录；
+1. EXE 安装版的默认目录 `%LOCALAPPDATA%\Programs\AbaqusCodexAssistant`；若其中存在 `runtime\python.exe`，项目 Python 就是该文件的绝对路径；
+2. 当前目录及其父目录；源码项目应同时包含 `pyproject.toml`、`configs/` 和 `src/abaqus_codex/`，项目 Python 是该项目下实际存在的 `.venv\Scripts\python.exe` 绝对路径；
 3. 用户明确提供的目录。
 
-默认目录存在时优先使用其中的私有 `.venv`，不要重新创建环境。不要无边界扫描用户文件，也不要根据维护者电脑猜测路径。以上位置均无法找到时，只问用户是否已经安装完整应用以及项目放在哪里；项目尚未安装时，读取 [references/setup.md](references/setup.md)。只安装本 Skill 不代表完整应用已经存在。
+不要仅凭目录存在就判断应用可用；必须确认对应的项目 Python 文件存在。不要无边界扫描用户文件，也不要根据维护者电脑猜测路径。以上位置均无法找到时，只问用户是否已经安装完整应用以及项目放在哪里；项目尚未安装时，读取 [references/setup.md](references/setup.md)。只安装本 Skill 不代表完整应用已经存在。
+
+普通用户应优先使用 EXE 安装版；它自带项目 Python，不要求用户另装 Python 或 Git。源码模式才使用项目自己的 `.venv`。无论哪种模式，先把实际文件解析为绝对路径并向用户显示；后续示例中的 `<检测到的项目 Python 绝对路径>` 必须替换为这个值，不能固定写成 `.venv`，也不能退回未知的系统 Python。
 
 在项目根目录运行统一只读体检；不要用零散命令替代首次体检：
 
 ```powershell
-.\.venv\Scripts\python.exe -m abaqus_codex onboard --json
+& "<检测到的项目 Python 绝对路径>" -m abaqus_codex onboard --json
 ```
 
 命令只检查，不会自动安装或登录。读取 JSON 后，用初学者可理解的语言分别解释项目 Python、Abaqus 内置 Python、abqpy、Abaqus MCP、Git、GitHub CLI 登录和 Zotero 状态；不能把 Git 已安装说成 GitHub 已登录，也不能把 MCP 已注册说成当前 Abaqus 会话已连接。ScienceDirect 机构访问只能标记为“需用户确认”。涉及 Abaqus 年份、Python 代际或 MCP 兼容性时，先读取 [references/version-compatibility.md](references/version-compatibility.md)，不能把“检测到”说成“已经验证支持”。然后只问一个问题：
@@ -58,7 +60,7 @@ description: 带 Abaqus 初学者逐步完成首次启动检查、选择建模�
 若 `configs/user_profile.json` 不存在，让用户从 `learning`（入门学习）、`paper`（论文复现）、`research`（科研参数分析）、`production`（实际工程）和 `teaching`（教学演示）中选择一个，然后运行：
 
 ```powershell
-.\.venv\Scripts\python.exe -m abaqus_codex configure --scenario <场景名称>
+& "<检测到的项目 Python 绝对路径>" -m abaqus_codex configure --scenario <场景名称>
 ```
 
 运行前说明该命令会创建本机 `configs/user_profile.json`，展示所选场景并征得确认；没有确认时只记录对话中的选择，不写文件。
@@ -98,7 +100,7 @@ description: 带 Abaqus 初学者逐步完成首次启动检查、选择建模�
 写入配置后运行：
 
 ```powershell
-.\.venv\Scripts\python.exe -m abaqus_codex validate --config <配置路径>
+& "<检测到的项目 Python 绝对路径>" -m abaqus_codex validate --config <配置路径>
 ```
 
 校验失败时只修正报告指出的问题，不绕过校验器。校验通过后给出一张简短摘要，至少包含几何、材料、载荷/位移、约束、网格和单位，并明确说明“Abaqus 尚未启动”。
@@ -110,7 +112,7 @@ description: 带 Abaqus 初学者逐步完成首次启动检查、选择建模�
 得到同意后运行：
 
 ```powershell
-.\.venv\Scripts\python.exe -m abaqus_codex run --config <配置路径>
+& "<检测到的项目 Python 绝对路径>" -m abaqus_codex run --config <配置路径>
 ```
 
 一次只启动一个新作业。失败后先读程序给出的日志路径和末尾错误，不用相同输入无休止重试。

--- a/skills/abaqus-modeling-guide/references/setup.md
+++ b/skills/abaqus-modeling-guide/references/setup.md
@@ -2,29 +2,44 @@
 
 只有项目不存在或环境体检发现缺项时才读取本文件。每次只处理一个缺项，并在联网、安装软件或修改用户配置前征得同意。
 
-## 定位已有项目
+## 优先定位 EXE 安装版
 
-项目根目录应同时包含：
+普通用户首选 EXE 安装版。默认安装目录是 `%LOCALAPPDATA%\Programs\AbaqusCodexAssistant`，项目 Python 固定放在：
+
+```text
+%LOCALAPPDATA%\Programs\AbaqusCodexAssistant\runtime\python.exe
+```
+
+先展开环境变量并解析为当前电脑上的绝对路径，再确认该文件真实存在。EXE 安装版自带项目 Python，普通用户无需另装 Python 或 Git。Abaqus 本体、合法许可证以及用户本人的 Codex 安装和登录不包含在应用中，仍需用户自行准备。
+
+## 定位源码项目
+
+源码项目根目录应同时包含：
 
 - `pyproject.toml`；
 - `configs/rectangle_tension.json`；
-- `src/abaqus_codex/`。
+- `src/abaqus_codex/`；
+- `.venv\Scripts\python.exe`。
 
 按以下顺序只读检查：
 
-1. 统一安装器的默认完整应用目录 `%LOCALAPPDATA%\Programs\AbaqusCodexAssistant`；
+1. EXE 安装版的默认完整应用目录 `%LOCALAPPDATA%\Programs\AbaqusCodexAssistant`；
 2. 当前目录及其父目录；
 3. 用户明确提供的目录。
 
-默认完整应用目录已经包含私有 `.venv`，找到后直接用它运行体检，不要再次创建环境。不要无边界扫描用户目录，也不要根据其他用户的电脑猜测路径。只安装到 `CODEX_HOME` 的本 Skill 不包含桌面应用或项目运行环境。
+每次都先确定并显示检测到的项目 Python 绝对路径：EXE 安装版使用 `runtime\python.exe`，源码版使用项目 `.venv\Scripts\python.exe`。不要无边界扫描用户目录，不要根据其他用户的电脑猜测路径，也不要退回系统 Python。只安装到 `CODEX_HOME` 的本 Skill 不包含桌面应用或项目运行环境。
 
 ## 项目尚未下载
 
-普通用户优先从项目的 [GitHub Releases](https://github.com/1721780603-cell/abaqus-codex-assistant/releases) 下载并完整解压发布包，再按项目根目录 `installer/README.md` 使用统一安装向导。不能只下载一个 `install.ps1`。安装器会先把完整应用放到 `%LOCALAPPDATA%\Programs\AbaqusCodexAssistant` 并安装 Skill，再检测 Abaqus；没有检测到 Abaqus 也不会撤销核心安装。仅当检测到维护者已验证的 Abaqus 2021 时，才额外安装安全修改插件。MCP 与 abqpy 仍需用户单独选择，因为它们会联网且有独立版本边界。
+普通用户优先从项目的 [GitHub Releases](https://github.com/1721780603-cell/abaqus-codex-assistant/releases) 下载 `AbaqusCodexAssistant-Setup-<版本>-x64.exe` 并双击安装。EXE 会安装自带的项目 Python、桌面助手和 Codex Skill，并创建启动入口；用户不需要下载源码、解压项目、运行 PowerShell，也不需要预装 Python 或 Git。
+
+EXE 不包含 Abaqus、许可证或 Codex 账号。安装核心应用不要求电脑已经安装 Abaqus，但真实建模仍需要用户自己的合法 Abaqus；Codex 智能模式仍使用用户本人安装并登录的 Codex。安装完成后先运行只读环境体检，再根据检测到的 Abaqus 年份逐项询问是否安装严格匹配的 abqpy，以及是否为 Codex 智能模式配置 MCP。abqpy 和 MCP 都可能联网或修改用户级配置，没有明确确认时不得安装。
+
+若 EXE 暂时无法使用，或用户明确参与开发，才使用同一 Release 的完整源码包或 Git 仓库。完整源码包必须整体解压，不能只下载一个 `install.ps1`。源码备用安装说明见项目根目录 `installer/README.md`。
 
 若 Codex 使用自定义 `CODEX_HOME`，统一安装器会优先把 Skill 放到该活动主目录；安装前先核对计划中显示的 Skill 目标。不要复制 Codex 凭据或会话文件。
 
-需要参与开发时，先确认 Git 可用，再询问用户希望把项目放在哪个父目录。得到同意后才执行：
+需要参与开发且选择 Git 克隆时，才确认 Git 可用，再询问用户希望把项目放在哪个父目录。得到同意后才执行：
 
 ```powershell
 git clone https://github.com/1721780603-cell/abaqus-codex-assistant.git
@@ -32,15 +47,16 @@ git clone https://github.com/1721780603-cell/abaqus-codex-assistant.git
 
 不要克隆到系统目录，也不要覆盖同名非空文件夹。
 
-## 使用统一安装的私有环境
+## 使用 EXE 安装版的内置运行时
 
-若项目位于 `%LOCALAPPDATA%\Programs\AbaqusCodexAssistant`，在该目录直接运行：
+若应用位于默认安装目录，先把项目 Python 解析为绝对路径并确认存在，再运行：
 
 ```powershell
-.\.venv\Scripts\python.exe -m abaqus_codex onboard --json
+$ProjectPython = [System.IO.Path]::GetFullPath("$env:LOCALAPPDATA\Programs\AbaqusCodexAssistant\runtime\python.exe")
+& $ProjectPython -m abaqus_codex onboard --json
 ```
 
-该环境由统一安装器维护。升级现有应用或 Skill 时，从新的完整 Release 目录运行 `installer/install.ps1 -Mode Repair`，不要在安装目录中手工覆盖文件。
+该运行时由 EXE 安装器维护，不要在安装目录中手工替换 Python 或包文件。升级应用时使用新的 EXE 安装包；不要从其他电脑复制运行时、Codex 凭据或会话文件。
 
 ## 创建源码开发环境
 
@@ -48,8 +64,9 @@ git clone https://github.com/1721780603-cell/abaqus-codex-assistant.git
 
 ```powershell
 py -m venv .venv
-.\.venv\Scripts\python.exe -m pip install -e .
-.\.venv\Scripts\python.exe -m abaqus_codex onboard --json
+$ProjectPython = (Resolve-Path ".\.venv\Scripts\python.exe").Path
+& $ProjectPython -m pip install -e .
+& $ProjectPython -m abaqus_codex onboard --json
 ```
 
 第一条只创建项目虚拟环境，第二条以可编辑方式安装本项目，第三条只做首次启动检查，不会自动安装或登录。若安装需要访问网络，先说明并请求同意。体检完成后按 [onboarding.md](onboarding.md) 只让用户选择一条下一步路线。
@@ -58,7 +75,7 @@ py -m venv .venv
 
 - **没有 Abaqus**：停止自动操作，引导用户从 Dassault Systèmes 官方渠道安装并配置合法许可证。不要替用户下载非官方安装包。
 - **检测到 Abaqus 2026**：只报告用户/项目实测兼容未通过，当前自动流程禁用。不要运行 `abqpy-setup --yes`、`mcp-setup`、`mcp-headless start` 或求解；不要猜测故障原因，等待项目修复和重新验证。
-- **Abaqus 2021–2025 可用、abqpy 缺失或版本不匹配**：先展示体检给出的 `abqpy==<年份>.*` 计划。得到同意后运行 `python -m abaqus_codex abqpy-setup --yes`；该命令只安装检测年份，不会失败后改装其他年份。
+- **Abaqus 2021–2025 可用、abqpy 缺失或版本不匹配**：先展示体检给出的 `abqpy==<年份>.*` 计划。得到同意后使用检测到的项目 Python 绝对路径运行 `-m abaqus_codex abqpy-setup --yes`；该命令只安装检测年份，不会失败后改装其他年份。
 - **MCP 缺失**：基础建模仍可继续。只有用户选择 Codex 智能模式时才介绍 `mcp-setup`；说明该命令会下载代码并修改用户级 MCP 配置，获得同意后才能带 `--yes` 执行。
 - **MCP 已配置但离线**：普通建模继续使用 CLI；用户需要 MCP 时再检查 `mcp-headless status`。
 - **GitHub、Zotero 或 ScienceDirect 未就绪**：不影响基础建模。只在用户选择“科研复现全套”或指定单项修复时处理，并遵守 [onboarding.md](onboarding.md) 中的凭据和付费墙安全边界。

--- a/src/abaqus_codex/__init__.py
+++ b/src/abaqus_codex/__init__.py
@@ -1,4 +1,14 @@
 # -*- coding: utf-8 -*-
 """Abaqus Codex Assistant 的核心程序包。"""
 
-__version__ = "0.2.1a1"
+__version__ = "0.2.2a1"
+
+# Windows 安装版把可选依赖放在当前用户的数据目录。源码安装和普通
+# site-packages 安装不改变解释器的搜索路径。
+try:
+    from abaqus_codex.paths import activate_user_python_packages
+
+    activate_user_python_packages()
+except (OSError, RuntimeError):
+    # 环境体检会给出可操作的诊断；包导入本身不应因可选目录异常而失败。
+    pass

--- a/src/abaqus_codex/abqpy_environment.py
+++ b/src/abaqus_codex/abqpy_environment.py
@@ -8,6 +8,8 @@ import sys
 from importlib import metadata
 from typing import Dict, Optional
 
+from abaqus_codex.paths import project_python_executable
+
 
 # Abaqus 和 abqpy 的新版版本号都以四位年份开头，例如 2021 和 2021.7.3。
 RELEASE_YEAR_PATTERN = re.compile(r"^(20\d{2})(?:\.|$)")
@@ -132,7 +134,7 @@ def inspect_abqpy(abaqus_version: Optional[str]) -> Dict[str, object]:
             abaqus_version
         ),
         "abaqus_verification_level": verification_level,
-        "python_executable": sys.executable,
+        "python_executable": str(project_python_executable()),
         "message": message,
     }
 

--- a/src/abaqus_codex/abqpy_setup.py
+++ b/src/abaqus_codex/abqpy_setup.py
@@ -3,9 +3,10 @@
 
 from __future__ import annotations
 
+import importlib
 import subprocess
-import sys
-from typing import Dict, List
+from pathlib import Path
+from typing import Dict, List, Optional
 
 from abaqus_codex.abqpy_environment import (
     inspect_abqpy,
@@ -13,24 +14,42 @@ from abaqus_codex.abqpy_environment import (
     recommended_abqpy_requirement,
 )
 from abaqus_codex.environment import inspect_abaqus
+from abaqus_codex.paths import (
+    activate_user_python_packages,
+    project_python_executable,
+)
 
 
 class AbqpySetupError(RuntimeError):
     """表示 abqpy 安装计划或安装验证没有安全完成。"""
 
 
-def build_install_command(requirement: str) -> List[str]:
+def build_install_command(
+    requirement: str, target: Optional[Path] = None
+) -> List[str]:
     """构造固定参数列表，确保依赖安装到当前项目 Python。"""
 
-    return [
-        sys.executable,
-        "-m",
-        "pip",
-        "install",
-        "--disable-pip-version-check",
-        "--upgrade",
-        requirement,
+    command = [
+        str(project_python_executable()),
     ]
+    # 安装版使用受 Setup 管理的私有 Python；可选包的 pip
+    # 子进程也必须忽略用户级 site-packages 和 PYTHON* 环境变量。
+    # 源码模式 target=None 时保持原有命令行语义。
+    if target is not None:
+        command.append("-I")
+    command.extend(
+        [
+            "-m",
+            "pip",
+            "install",
+            "--disable-pip-version-check",
+            "--upgrade",
+        ]
+    )
+    if target is not None:
+        command.extend(["--target", str(target)])
+    command.append(requirement)
+    return command
 
 
 def _run_install(command: List[str], timeout_seconds: int = 600) -> None:
@@ -83,6 +102,7 @@ def setup_abqpy(confirmed: bool) -> Dict[str, object]:
             "无法从 Abaqus 版本生成安全的 abqpy 年份规格，未执行安装。"
         )
 
+    package_target = activate_user_python_packages(create=True)
     before = inspect_abqpy(abaqus["version"])
     if before["usable"]:
         return {
@@ -93,8 +113,9 @@ def setup_abqpy(confirmed: bool) -> Dict[str, object]:
             "message": "匹配年份的 abqpy 已可用，未重复安装。",
         }
 
-    command = build_install_command(requirement)
+    command = build_install_command(requirement, target=package_target)
     _run_install(command)
+    importlib.invalidate_caches()
     after = inspect_abqpy(abaqus["version"])
     if not after["usable"]:
         raise AbqpySetupError(

--- a/src/abaqus_codex/cli.py
+++ b/src/abaqus_codex/cli.py
@@ -12,6 +12,7 @@ from typing import Optional, Sequence
 from abaqus_codex.configuration import ConfigurationError, load_config
 from abaqus_codex.doctor import main as doctor_main
 from abaqus_codex.local_ai import LocalAIError, SUPPORTED_PROVIDERS
+from abaqus_codex.paths import resource_root, user_data_root
 from abaqus_codex.scenario import SCENARIOS, prompt_scenario, save_profile
 
 
@@ -25,15 +26,15 @@ def _configure_utf8_output() -> None:
 
 
 def project_root() -> Path:
-    """返回源码所在项目根目录。"""
+    """返回安装版或源码模式的只读资源根。"""
 
-    return Path(__file__).resolve().parents[2]
+    return resource_root()
 
 
 def _build_parser() -> argparse.ArgumentParser:
     """创建命令行参数解析器。"""
 
-    root = project_root()
+    data_root = user_data_root()
     parser = argparse.ArgumentParser(
         prog="abaqus-codex",
         description="面向初学者的 Abaqus 环境体检、建模和结果报告工具。",
@@ -75,6 +76,56 @@ def _build_parser() -> argparse.ArgumentParser:
         "--yes",
         action="store_true",
         help="确认安装到当前用户的 abaqus_plugins；不同旧版会先备份。",
+    )
+
+    integration_setup_parser = subparsers.add_parser(
+        "integration-setup",
+        help="为当前用户安装 Codex Skill 和已验证的 Abaqus 插件。",
+    )
+    integration_setup_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="确认写入当前用户的 Skill/插件目录。",
+    )
+    integration_setup_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="只校验资源和安装计划，不写入任何目录。",
+    )
+    integration_setup_parser.add_argument(
+        "--codex-home",
+        type=Path,
+        help="显式指定 Codex 用户目录；默认遵循 CODEX_HOME。",
+    )
+    integration_setup_parser.add_argument(
+        "--data-root",
+        type=Path,
+        help="安装器显式锁定的用户数据/恢复目录。",
+    )
+    integration_setup_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="输出便于安装器读取的 JSON 结果。",
+    )
+
+    integration_remove_parser = subparsers.add_parser(
+        "integration-remove",
+        help="恢复安装前的 Skill/插件，并保留用户改过的目录。",
+    )
+    integration_remove_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="确认移除当前用户的受管集成。",
+    )
+    integration_remove_parser.add_argument(
+        "--data-root",
+        type=Path,
+        help="卸载器显式锁定的用户数据/恢复目录。",
+    )
+    integration_remove_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="输出便于卸载器读取的 JSON 结果。",
     )
 
     install_preflight_parser = subparsers.add_parser(
@@ -150,7 +201,7 @@ def _build_parser() -> argparse.ArgumentParser:
     configure_parser.add_argument(
         "--output",
         type=Path,
-        default=root / "configs" / "user_profile.json",
+        default=data_root / "configs" / "user_profile.json",
         help="场景配置保存位置。",
     )
 
@@ -189,7 +240,7 @@ def _build_parser() -> argparse.ArgumentParser:
     local_ai_generate.add_argument(
         "--output",
         type=Path,
-        default=root / "configs" / "local_ai_rectangle.json",
+        default=data_root / "configs" / "local_ai_rectangle.json",
         help="确认后保存的 JSON 路径。",
     )
     local_ai_generate.add_argument(
@@ -215,19 +266,19 @@ def _build_parser() -> argparse.ArgumentParser:
     run_parser.add_argument(
         "--config",
         type=Path,
-        default=root / "configs" / "rectangle_tension.json",
+        default=None,
         help="内置 Abaqus 模型的 JSON 配置文件。",
     )
     run_parser.add_argument(
         "--work-root",
         type=Path,
-        default=root / "work" / "runs",
+        default=data_root / "work" / "runs",
         help="Abaqus 临时作业根目录。",
     )
     run_parser.add_argument(
         "--output-root",
         type=Path,
-        default=root / "outputs",
+        default=data_root / "outputs",
         help="结果和报告输出根目录。",
     )
     run_parser.add_argument(
@@ -266,18 +317,66 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             )
 
         if args.command == "assistant-setup":
-            from abaqus_codex.safe_action_setup import setup_safe_action_plugin
+            from abaqus_codex.paths import is_private_runtime
 
-            result = setup_safe_action_plugin(
-                confirmed=args.yes,
-                dry_run=args.dry_run,
-            )
+            if is_private_runtime():
+                from abaqus_codex.distribution_integration import integration_setup
+
+                integrated = integration_setup(
+                    confirmed=args.yes,
+                    dry_run=args.dry_run,
+                )
+                result = integrated["plugin"]
+            else:
+                from abaqus_codex.safe_action_setup import setup_safe_action_plugin
+
+                result = setup_safe_action_plugin(
+                    confirmed=args.yes,
+                    dry_run=args.dry_run,
+                )
             print(result["message"])
             print("目标目录：{0}".format(result["target"]))
             if result["backup"]:
                 print("旧版备份：{0}".format(result["backup"]))
-            if not result["dry_run"] and result["changed"]:
+            # 安装版路由返回的是集成清单里的 plugin 子项，
+            # 它不单独重复 dry_run 字段；以 CLI 已解析的参数为准。
+            if not args.dry_run and result["changed"]:
                 print("请关闭并重新打开 Abaqus/CAE 2021 后再使用助手。")
+            return 0
+
+        if args.command == "integration-setup":
+            from abaqus_codex.distribution_integration import integration_setup
+
+            result = integration_setup(
+                confirmed=args.yes,
+                codex_home_path=args.codex_home,
+                data_root=args.data_root,
+                dry_run=args.dry_run,
+            )
+            if args.json:
+                print(json.dumps(result, ensure_ascii=False, indent=2))
+            else:
+                skill = result["skill"]
+                plugin = result["plugin"]
+                print("Codex Skill：{0}".format(skill["target"]))
+                print("安全插件：{0}".format(plugin["message"]))
+                if not result["dry_run"]:
+                    print("用户集成清单：{0}".format(result["manifest_path"]))
+            return 0
+
+        if args.command == "integration-remove":
+            from abaqus_codex.distribution_integration import integration_remove
+
+            result = integration_remove(
+                confirmed=args.yes,
+                data_root=args.data_root,
+            )
+            if args.json:
+                print(json.dumps(result, ensure_ascii=False, indent=2))
+            else:
+                print("Codex Skill：{0}".format(result["skill"]["status"]))
+                print("Abaqus 安全插件：{0}".format(result["plugin"]["status"]))
+                print("原清单已作为可恢复记录保留。")
             return 0
 
         if args.command == "install-preflight":
@@ -398,8 +497,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             # 延后导入，保证仅使用 doctor/configure 时不加载求解流程。
             from abaqus_codex.workflow import run_analysis
 
+            config_path = args.config
+            if config_path is None:
+                config_path = project_root() / "configs" / "rectangle_tension.json"
             result = run_analysis(
-                config_path=args.config.resolve(),
+                config_path=config_path.resolve(),
                 work_root=args.work_root.resolve(),
                 output_root=args.output_root.resolve(),
                 timeout_seconds=args.timeout,

--- a/src/abaqus_codex/desktop_assistant/__init__.py
+++ b/src/abaqus_codex/desktop_assistant/__init__.py
@@ -92,8 +92,14 @@ def _configure_tk_runtime(
     *,
     candidate_roots: Optional[Iterable[Path]] = None,
     environment: Optional[MutableMapping[str, str]] = None,
+    working_directory: Optional[Path] = None,
 ) -> bool:
-    """在 Windows Python 未自动定位 Tcl/Tk 时补充当前进程环境。"""
+    """在 Windows Python 未自动定位 Tcl/Tk 时补充当前进程环境。
+
+    Windows 自带的 Tcl 8.6 在部分非 ASCII 安装路径下不能可靠地从
+    绝对环境变量加载 ``init.tcl``。相对当前工作目录的路径仍由 Tcl
+    正确解析，所以优先写入正斜杠相对路径；跨盘符时才退回绝对路径。
+    """
 
     target_environment = os.environ if environment is None else environment
     if target_environment.get("TCL_LIBRARY") and target_environment.get(
@@ -115,8 +121,15 @@ def _configure_tk_runtime(
             tk_directory = root / ("tk" + version)
             if not (tk_directory / "tk.tcl").is_file():
                 continue
-            target_environment.setdefault("TCL_LIBRARY", str(tcl_directory))
-            target_environment.setdefault("TK_LIBRARY", str(tk_directory))
+            base = Path.cwd() if working_directory is None else Path(working_directory)
+            try:
+                tcl_value = Path(os.path.relpath(tcl_directory, base)).as_posix()
+                tk_value = Path(os.path.relpath(tk_directory, base)).as_posix()
+            except (OSError, ValueError):
+                tcl_value = tcl_directory.as_posix()
+                tk_value = tk_directory.as_posix()
+            target_environment.setdefault("TCL_LIBRARY", tcl_value)
+            target_environment.setdefault("TK_LIBRARY", tk_value)
             return True
     return False
 

--- a/src/abaqus_codex/desktop_assistant/codex_app_server.py
+++ b/src/abaqus_codex/desktop_assistant/codex_app_server.py
@@ -14,7 +14,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Optional
 
+from abaqus_codex import __version__
 from abaqus_codex.desktop_assistant.codex_status import _find_codex_executable
+from abaqus_codex.paths import user_data_root
 
 
 MAX_PROTOCOL_LINE = 2 * 1024 * 1024
@@ -127,9 +129,7 @@ def normalize_ai_prompt(value: object) -> str:
 def default_ai_workspace() -> Path:
     """使用不含 CAE 文件的独立目录作为只读咨询工作区。"""
 
-    local_data = os.environ.get("LOCALAPPDATA", "").strip()
-    base = Path(local_data) if local_data else Path.home()
-    return (base / "AbaqusCodexAssistant" / "ai_workspace").resolve()
+    return (user_data_root() / "ai_workspace").resolve()
 
 
 class CodexReadOnlyClient:
@@ -200,7 +200,7 @@ class CodexReadOnlyClient:
                 "clientInfo": {
                     "name": "abaqus_codex_assistant",
                     "title": "Abaqus 中文建模助手",
-                    "version": "0.2.0a1",
+                    "version": __version__,
                 }
             },
             timeout_seconds=15.0,

--- a/src/abaqus_codex/distribution_integration.py
+++ b/src/abaqus_codex/distribution_integration.py
@@ -1,0 +1,912 @@
+# -*- coding: utf-8 -*-
+"""安装版对 Codex Skill 和已验证 Abaqus 插件的用户级集成。"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Mapping, Optional
+
+from abaqus_codex import __version__
+from abaqus_codex.abqpy_environment import parse_release_year
+from abaqus_codex.environment import inspect_abaqus
+from abaqus_codex.paths import resource_root, user_data_root
+from abaqus_codex.safe_action_setup import (
+    PLUGIN_DIRECTORY_NAME,
+    SUPPORTED_ABAQUS_YEAR,
+    SafeActionSetupError,
+    default_plugin_target,
+    setup_safe_action_plugin,
+)
+
+
+PRODUCT_NAME = "abaqus-codex-assistant"
+SKILL_DIRECTORY_NAME = "abaqus-modeling-guide"
+MANIFEST_FILENAME = "integration-manifest.json"
+MANIFEST_SCHEMA_VERSION = 1
+WINDOWS_REPARSE_POINT = 0x0400
+
+
+class DistributionIntegrationError(RuntimeError):
+    """发布版用户集成不能安全完成。"""
+
+
+def _lexical_absolute(path: Path) -> Path:
+    """返回不解析符号链接或 junction 的绝对路径。"""
+
+    return Path(os.path.abspath(os.path.expanduser(os.fspath(path))))
+
+
+def _lexical_paths_equal(left: object, right: Path) -> bool:
+    """按当前平台的路径语义比较，不解析 symlink 或 junction。"""
+
+    left_text = str(left or "").strip()
+    if not left_text:
+        return False
+    left_key = os.path.normcase(os.fspath(_lexical_absolute(Path(left_text))))
+    right_key = os.path.normcase(os.fspath(_lexical_absolute(right)))
+    return left_key == right_key
+
+
+def _is_reparse_point(path: Path) -> bool:
+    """不跟随目标地检查 symlink、Windows junction 及其他重解析点。"""
+
+    try:
+        if path.is_symlink():
+            return True
+    except OSError:
+        return True
+    is_junction = getattr(path, "is_junction", None)
+    if callable(is_junction):
+        try:
+            if is_junction():
+                return True
+        except OSError:
+            return True
+    try:
+        stat_result = path.lstat()
+    except FileNotFoundError:
+        return False
+    except OSError:
+        # 无法安全识别的现有路径一律失败关闭。
+        return True
+    attributes = int(getattr(stat_result, "st_file_attributes", 0) or 0)
+    return bool(attributes & WINDOWS_REPARSE_POINT)
+
+
+def _assert_no_reparse_path(path: Path, *, label: str) -> None:
+    """检查目标和所有现有父路径，避免安装/卸载越界。"""
+
+    current = _lexical_absolute(path)
+    while True:
+        if _is_reparse_point(current):
+            raise DistributionIntegrationError(
+                "{0}包含符号链接或 Windows 联接点，未更改文件：{1}".format(
+                    label, current
+                )
+            )
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+
+
+def _digest_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while True:
+            block = stream.read(1024 * 1024)
+            if not block:
+                break
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _directory_manifest(root: Path) -> Dict[str, str]:
+    """读取不跟随符号链接的完整目录指纹。"""
+
+    if _is_reparse_point(root):
+        raise DistributionIntegrationError(
+            "受管目录不能是符号链接或 Windows 联接点：{0}".format(root)
+        )
+    if not root.is_dir():
+        raise DistributionIntegrationError("没有找到完整目录：{0}".format(root))
+    entries: Dict[str, str] = {}
+
+    def visit(directory: Path) -> None:
+        try:
+            with os.scandir(directory) as scan:
+                children = sorted(scan, key=lambda item: item.name)
+        except OSError as error:
+            raise DistributionIntegrationError(
+                "无法安全读取受管目录：{0}".format(directory)
+            ) from error
+        for child in children:
+            path = directory / child.name
+            relative = path.relative_to(root).as_posix()
+            if _is_reparse_point(path):
+                raise DistributionIntegrationError(
+                    "目录中含有符号链接或 Windows 联接点，已停止：{0}".format(
+                        relative
+                    )
+                )
+            if child.is_dir(follow_symlinks=False):
+                entries["目录:" + relative] = ""
+                visit(path)
+            elif child.is_file(follow_symlinks=False):
+                entries["文件:" + relative] = _digest_file(path)
+            else:
+                raise DistributionIntegrationError(
+                    "目录中含有不支持的文件类型：{0}".format(relative)
+                )
+
+    visit(root)
+    return entries
+
+
+def _directory_digest(root: Path) -> str:
+    payload = json.dumps(
+        _directory_manifest(root),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _timestamp() -> str:
+    return datetime.now().strftime("%Y%m%d-%H%M%S")
+
+
+def _next_recovery_path(recovery_root: Path, target: Path, label: str) -> Path:
+    """在用户数据恢复区中生成唯一路径，避免被 Codex/Abaqus 扫描。"""
+
+    recovery_root = _lexical_absolute(recovery_root)
+    _assert_no_reparse_path(recovery_root, label="用户恢复路径")
+    base = recovery_root / "{0}.{1}-{2}".format(target.name, label, _timestamp())
+    if not base.exists() and not base.is_symlink():
+        return base
+    for index in range(1, 1000):
+        candidate = recovery_root / "{0}-{1:03d}".format(base.name, index)
+        if not candidate.exists() and not candidate.is_symlink():
+            return candidate
+    raise DistributionIntegrationError("同名恢复副本过多，请先人工整理：{0}".format(recovery_root))
+
+
+def _move_directory(source: Path, destination: Path) -> None:
+    """仅使用同卷原子改名；绝不用复制后递归删除来伪装移动。"""
+
+    source = _lexical_absolute(source)
+    destination = _lexical_absolute(destination)
+    _assert_no_reparse_path(source, label="待移动目录")
+    _assert_no_reparse_path(destination, label="恢复目标路径")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    _assert_no_reparse_path(destination.parent, label="恢复目标父路径")
+    try:
+        source.replace(destination)
+    except OSError as error:
+        raise DistributionIntegrationError(
+            "无法将目录原子移入用户恢复区；"
+            "请确保 CODEX_HOME、Abaqus 插件目录和 LOCALAPPDATA 位于同一磁盘。"
+        ) from error
+
+
+def _nearest_existing_path(path: Path) -> Path:
+    current = _lexical_absolute(path)
+    while not current.exists() and current.parent != current:
+        current = current.parent
+    return current
+
+
+def _same_storage_volume(left: Path, right: Path) -> bool:
+    """在任何复制前判断目标与恢复区能否用原子改名往返。"""
+
+    left = _lexical_absolute(left)
+    right = _lexical_absolute(right)
+    left_drive = os.path.normcase(os.path.splitdrive(str(left))[0])
+    right_drive = os.path.normcase(os.path.splitdrive(str(right))[0])
+    if left_drive or right_drive:
+        return bool(left_drive and left_drive == right_drive)
+    try:
+        return _nearest_existing_path(left).stat().st_dev == _nearest_existing_path(right).stat().st_dev
+    except OSError:
+        return False
+
+
+def _staging_path(target: Path) -> Path:
+    for _unused in range(20):
+        candidate = target.with_name(
+            ".{0}.installing-{1}".format(target.name, uuid.uuid4().hex[:12])
+        )
+        if not candidate.exists() and not candidate.is_symlink():
+            return candidate
+    raise DistributionIntegrationError("无法创建唯一的临时安装目录。")
+
+
+def _install_directory(
+    source: Path,
+    target: Path,
+    *,
+    recovery_root: Path,
+    dry_run: bool,
+) -> Dict[str, object]:
+    """先校验、再复制、最后整体换入，且始终保留旧目录。"""
+
+    source = _lexical_absolute(source)
+    target = _lexical_absolute(target)
+    recovery_root = _lexical_absolute(recovery_root)
+    _assert_no_reparse_path(source, label="集成资源路径")
+    _assert_no_reparse_path(target, label="集成目标路径")
+    _assert_no_reparse_path(recovery_root, label="用户恢复路径")
+    if not source.is_dir():
+        raise DistributionIntegrationError("没有找到完整目录：{0}".format(source))
+    if (
+        source == target
+        or source in target.parents
+        or target in source.parents
+        or recovery_root == target.parent
+        or target.parent in recovery_root.parents
+    ):
+        raise DistributionIntegrationError(
+            "集成资源、目标和恢复区不能相互重叠，"
+            "恢复区也不能位于 Codex/Abaqus 扫描目录内。"
+        )
+    if not _same_storage_volume(target.parent, recovery_root):
+        raise DistributionIntegrationError(
+            "集成目标与用户恢复区不在同一磁盘；"
+            "为保证可原子恢复，已在复制前停止。"
+        )
+
+    source_digest = _directory_digest(source)
+    target_exists = target.exists()
+    if target_exists and not target.is_dir():
+        raise DistributionIntegrationError("集成目标已存在且不是目录：{0}".format(target))
+    if target_exists and _directory_digest(target) == source_digest:
+        return {
+            "changed": False,
+            "source": str(source),
+            "target": str(target),
+            "backup": None,
+            "recovery_root": str(recovery_root),
+            "installed_digest": source_digest,
+        }
+
+    backup = (
+        _next_recovery_path(recovery_root, target, "backup")
+        if target_exists
+        else None
+    )
+    if dry_run:
+        return {
+            "changed": True,
+            "source": str(source),
+            "target": str(target),
+            "backup": str(backup) if backup is not None else None,
+            "recovery_root": str(recovery_root),
+            "installed_digest": source_digest,
+        }
+
+    stage = _staging_path(target)
+    try:
+        _assert_no_reparse_path(target, label="集成目标路径")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        _assert_no_reparse_path(target.parent, label="集成目标父路径")
+        shutil.copytree(source, stage, copy_function=shutil.copy2)
+        if _directory_digest(stage) != source_digest:
+            raise DistributionIntegrationError("临时集成副本校验失败。")
+    except (OSError, shutil.Error, DistributionIntegrationError) as error:
+        # 不递归删除失败副本；改名后供诊断和恢复。
+        if stage.exists() and not stage.is_symlink():
+            try:
+                failed_copy = _next_recovery_path(recovery_root, target, "failed-copy")
+                _move_directory(stage, failed_copy)
+            except (OSError, DistributionIntegrationError):
+                pass
+        raise DistributionIntegrationError("复制集成资源失败，原目录未更改。") from error
+
+    backed_up = False
+    try:
+        _assert_no_reparse_path(target, label="集成目标路径")
+        if backup is not None:
+            _move_directory(target, backup)
+            backed_up = True
+        stage.replace(target)
+    except (OSError, DistributionIntegrationError) as error:
+        if backed_up and backup is not None and not target.exists():
+            try:
+                _move_directory(backup, target)
+            except (OSError, DistributionIntegrationError):
+                pass
+        if stage.exists() and not stage.is_symlink():
+            try:
+                failed_switch = _next_recovery_path(
+                    recovery_root, target, "failed-switch"
+                )
+                _move_directory(stage, failed_switch)
+            except (OSError, DistributionIntegrationError):
+                pass
+        raise DistributionIntegrationError(
+            "切换集成目录失败；没有递归删除任何用户目录。"
+        ) from error
+
+    return {
+        "changed": True,
+        "source": str(source),
+        "target": str(target),
+        "backup": str(backup) if backup is not None else None,
+        "recovery_root": str(recovery_root),
+        "installed_digest": source_digest,
+    }
+
+
+def _manifest_path(data_root: Optional[Path]) -> Path:
+    selected = _lexical_absolute(Path(data_root) if data_root is not None else user_data_root())
+    return selected / MANIFEST_FILENAME
+
+
+def _selected_codex_home(explicit: Optional[Path]) -> Path:
+    """选择 CODEX_HOME，但不在安全检查前解析链接/junction。"""
+
+    if explicit is not None and str(explicit).strip():
+        return _lexical_absolute(explicit)
+    environment_value = os.environ.get("CODEX_HOME", "").strip()
+    if environment_value:
+        return _lexical_absolute(Path(environment_value))
+    user_profile = os.environ.get("USERPROFILE", "").strip()
+    home = Path(user_profile) if user_profile else Path.home()
+    return _lexical_absolute(home / ".codex")
+
+
+def _read_manifest(path: Path, *, required: bool) -> Optional[dict[str, object]]:
+    _assert_no_reparse_path(path, label="用户集成清单路径")
+    if not path.is_file():
+        if required:
+            raise DistributionIntegrationError("未找到用户集成清单，未更改任何文件。")
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, TypeError, ValueError) as error:
+        raise DistributionIntegrationError("用户集成清单已损坏，未更改任何文件。") from error
+    if (
+        not isinstance(payload, dict)
+        or payload.get("product") != PRODUCT_NAME
+        or payload.get("schema_version") != MANIFEST_SCHEMA_VERSION
+    ):
+        raise DistributionIntegrationError("用户集成清单不受支持，未更改任何文件。")
+    return payload
+
+
+def _write_manifest(path: Path, payload: Mapping[str, object]) -> None:
+    _assert_no_reparse_path(path, label="用户集成清单路径")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _assert_no_reparse_path(path.parent, label="用户集成清单父路径")
+    stage = path.with_name(".{0}.writing-{1}".format(path.name, uuid.uuid4().hex[:12]))
+    try:
+        stage.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        stage.replace(path)
+    except OSError as error:
+        if stage.exists():
+            try:
+                failed_write = _next_recovery_path(
+                    path.parent / "recovery" / "manifest", path, "failed-write"
+                )
+                _move_directory(stage, failed_write)
+            except (OSError, DistributionIntegrationError):
+                pass
+        raise DistributionIntegrationError("无法写入用户集成清单。") from error
+
+
+def _prior_component(
+    manifest: Optional[Mapping[str, object]], name: str, target: Path
+) -> Mapping[str, object]:
+    if not isinstance(manifest, Mapping):
+        return {}
+    component = manifest.get(name)
+    if not isinstance(component, Mapping):
+        return {}
+    if not _lexical_paths_equal(component.get("target"), target):
+        return {}
+    return component
+
+
+def _validate_prior_manifest_targets(
+    manifest: Mapping[str, object],
+    *,
+    manifest_path: Path,
+    selected_codex_home: Path,
+    skill_target: Path,
+    plugin_target: Path,
+) -> None:
+    """不允许新的 CODEX_HOME/用户目标覆盖尚未移除的旧集成清单。"""
+
+    recorded_data = _lexical_absolute(Path(str(manifest.get("user_data_root") or "")))
+    recorded_codex = _lexical_absolute(Path(str(manifest.get("codex_home") or "")))
+    prior_skill = manifest.get("skill")
+    prior_plugin = manifest.get("plugin")
+    recorded_skill = (
+        _lexical_absolute(Path(str(prior_skill.get("target") or "")))
+        if isinstance(prior_skill, Mapping)
+        else None
+    )
+    recorded_plugin = (
+        _lexical_absolute(Path(str(prior_plugin.get("target") or "")))
+        if isinstance(prior_plugin, Mapping)
+        else None
+    )
+    if (
+        recorded_data != manifest_path.parent
+        or recorded_codex != selected_codex_home
+        or recorded_skill != skill_target
+        or recorded_plugin != plugin_target
+    ):
+        raise DistributionIntegrationError(
+            "已有集成清单属于另一个 CODEX_HOME 或用户目标；"
+            "请先使用原配置运行 integration-remove，再重新安装。"
+        )
+    for name, component in (("skill", prior_skill), ("plugin", prior_plugin)):
+        if not isinstance(component, Mapping) or not bool(component.get("managed")):
+            continue
+        recovery_text = str(component.get("recovery_root") or "").strip()
+        expected_recovery = manifest_path.parent / "recovery" / name
+        if not recovery_text or _lexical_absolute(Path(recovery_text)) != expected_recovery:
+            raise DistributionIntegrationError(
+                "历史集成清单使用了扫描目录旁的旧备份；"
+                "本版不会自动迁移或删除，请先人工确认。"
+            )
+
+
+def _component_with_ownership(
+    result: Mapping[str, object],
+    prior: Mapping[str, object],
+    *,
+    preserve_initial_backup: bool = False,
+) -> dict[str, object]:
+    component = dict(result)
+    changed = bool(component.get("changed"))
+    component["managed"] = changed or bool(prior.get("managed"))
+    prior_recoveries = prior.get("upgrade_recoveries")
+    recoveries = (
+        [str(item) for item in prior_recoveries if str(item).strip()]
+        if isinstance(prior_recoveries, list)
+        else []
+    )
+    if not changed:
+        component["backup"] = prior.get("backup")
+        component["recovery_root"] = (
+            prior.get("recovery_root") or component.get("recovery_root")
+        )
+    elif preserve_initial_backup:
+        new_upgrade_recovery = component.get("backup")
+        if new_upgrade_recovery:
+            recoveries.append(str(new_upgrade_recovery))
+        component["backup"] = prior.get("backup")
+    component["upgrade_recoveries"] = recoveries
+    return component
+
+
+def _prior_managed_target_is_unchanged(
+    prior: Mapping[str, object], target: Path
+) -> bool:
+    """判断当前目标是上一版受管副本，而不是用户新内容。"""
+
+    if not bool(prior.get("managed")):
+        return False
+    if not _lexical_paths_equal(prior.get("target"), target):
+        return False
+    expected = str(prior.get("installed_digest") or "")
+    if not expected or not target.is_dir():
+        return False
+    _assert_no_reparse_path(target, label="已安装集成目标")
+    return _directory_digest(target) == expected
+
+
+def _mark_upgrade_recovery(
+    result: Mapping[str, object],
+    *,
+    target: Path,
+    recovery_root: Path,
+    dry_run: bool,
+) -> dict[str, object]:
+    """把已受管的旧程序版标记为升级恢复，不替代首次用户备份。"""
+
+    updated = dict(result)
+    backup_text = str(updated.get("backup") or "").strip()
+    if not bool(updated.get("changed")) or not backup_text:
+        return updated
+    backup = _lexical_absolute(Path(backup_text))
+    upgrade = _next_recovery_path(recovery_root, target, "upgrade")
+    if not dry_run:
+        _move_directory(backup, upgrade)
+    updated["backup"] = str(upgrade)
+    return updated
+
+
+def _rollback_install(component: Mapping[str, object]) -> None:
+    """尽力撤回本轮换入；失败副本仍以可恢复改名保留。"""
+
+    if not bool(component.get("changed")):
+        return
+    target_text = str(component.get("target") or "").strip()
+    if not target_text:
+        return
+    target = _lexical_absolute(Path(target_text))
+    recovery_root = _component_recovery_root(component, target)
+    recoveries = component.get("upgrade_recoveries")
+    if isinstance(recoveries, list) and recoveries:
+        backup = _valid_backup(
+            target, recoveries[-1], recovery_root, label="upgrade"
+        )
+    else:
+        backup = _valid_backup(
+            target, component.get("backup"), recovery_root
+        )
+    installed_digest = str(component.get("installed_digest") or "")
+    if target.is_dir() and not target.is_symlink():
+        try:
+            if installed_digest and _directory_digest(target) == installed_digest:
+                failed_install = _next_recovery_path(
+                    recovery_root, target, "failed-install"
+                )
+                _move_directory(target, failed_install)
+        except (OSError, DistributionIntegrationError):
+            return
+    if backup is not None and backup.is_dir() and not target.exists():
+        try:
+            _move_directory(backup, target)
+        except (OSError, DistributionIntegrationError):
+            pass
+
+
+def integration_setup(
+    *,
+    confirmed: bool,
+    codex_home_path: Optional[Path] = None,
+    data_root: Optional[Path] = None,
+    dry_run: bool = False,
+) -> Dict[str, object]:
+    """安装 Skill，并仅对实时验证的 Abaqus 2021 安装安全插件。"""
+
+    if not confirmed and not dry_run:
+        raise DistributionIntegrationError(
+            "集成会写入 Codex Skill 和可能的 Abaqus 用户插件目录；"
+            "请明确确认。"
+        )
+
+    resources = resource_root()
+    selected_codex_home = _selected_codex_home(codex_home_path)
+    manifest_path = _manifest_path(data_root)
+    prior_manifest = _read_manifest(manifest_path, required=False)
+    skill_source = resources / "skills" / SKILL_DIRECTORY_NAME
+    if not (skill_source / "SKILL.md").is_file():
+        raise DistributionIntegrationError("Skill 资源不完整，缺少 SKILL.md。")
+    selected_codex_home = _lexical_absolute(selected_codex_home)
+    skill_target = _lexical_absolute(
+        selected_codex_home / "skills" / SKILL_DIRECTORY_NAME
+    )
+    plugin_target = _lexical_absolute(default_plugin_target())
+    if prior_manifest is not None:
+        _validate_prior_manifest_targets(
+            prior_manifest,
+            manifest_path=manifest_path,
+            selected_codex_home=selected_codex_home,
+            skill_target=skill_target,
+            plugin_target=plugin_target,
+        )
+    skill_recovery_root = manifest_path.parent / "recovery" / "skill"
+    plugin_recovery_root = manifest_path.parent / "recovery" / "plugin"
+    prior_skill = _prior_component(prior_manifest, "skill", skill_target)
+    preserve_skill_backup = _prior_managed_target_is_unchanged(
+        prior_skill, skill_target
+    )
+    skill_result = _install_directory(
+        skill_source,
+        skill_target,
+        recovery_root=skill_recovery_root,
+        dry_run=dry_run,
+    )
+    if preserve_skill_backup:
+        skill_result = _mark_upgrade_recovery(
+            skill_result,
+            target=skill_target,
+            recovery_root=skill_recovery_root,
+            dry_run=dry_run,
+        )
+    skill = _component_with_ownership(
+        skill_result,
+        prior_skill,
+        preserve_initial_backup=preserve_skill_backup,
+    )
+
+    abaqus = inspect_abaqus()
+    year = parse_release_year(abaqus.get("version"))
+    plugin_eligible = bool(
+        abaqus.get("usable") and year == SUPPORTED_ABAQUS_YEAR
+    )
+    prior_plugin = _prior_component(prior_manifest, "plugin", plugin_target)
+    preserve_plugin_backup = _prior_managed_target_is_unchanged(
+        prior_plugin, plugin_target
+    )
+    plugin: dict[str, object] = {
+        "eligible": plugin_eligible,
+        "managed": bool(prior_plugin.get("managed")),
+        "changed": False,
+        "source": str(resources / "abaqus_plugins" / PLUGIN_DIRECTORY_NAME),
+        "target": str(plugin_target),
+        "backup": prior_plugin.get("backup"),
+        "recovery_root": str(plugin_recovery_root),
+        "upgrade_recoveries": prior_plugin.get("upgrade_recoveries") or [],
+        "installed_digest": prior_plugin.get("installed_digest"),
+        "message": (
+            "已验证 Abaqus 2021，可安装安全插件。"
+            if plugin_eligible
+            else "未检测到已验证的 Abaqus 2021，已跳过安全插件。"
+        ),
+    }
+    if plugin_eligible:
+        if dry_run:
+            plugin_result = setup_safe_action_plugin(
+                confirmed=False,
+                dry_run=True,
+                source=resources / "abaqus_plugins" / PLUGIN_DIRECTORY_NAME,
+                target=plugin_target,
+                backup_root=plugin_recovery_root,
+            )
+        else:
+            try:
+                plugin_result = setup_safe_action_plugin(
+                    confirmed=True,
+                    source=resources / "abaqus_plugins" / PLUGIN_DIRECTORY_NAME,
+                    target=plugin_target,
+                    backup_root=plugin_recovery_root,
+                )
+            except SafeActionSetupError as error:
+                _rollback_install(skill)
+                raise DistributionIntegrationError(
+                    "Abaqus 2021 安全插件未安装：{0}".format(error)
+                ) from error
+        plugin_digest = (
+            _directory_digest(plugin_target)
+            if not dry_run and plugin_target.is_dir()
+            else _directory_digest(resources / "abaqus_plugins" / PLUGIN_DIRECTORY_NAME)
+        )
+        normalized_plugin = {
+            "eligible": True,
+            "changed": bool(plugin_result.get("changed")),
+            "source": str(plugin_result.get("source")),
+            "target": str(plugin_result.get("target")),
+            "backup": plugin_result.get("backup"),
+            "recovery_root": str(plugin_recovery_root),
+            "installed_digest": plugin_digest,
+            "message": str(plugin_result.get("message") or ""),
+        }
+        if preserve_plugin_backup:
+            normalized_plugin = _mark_upgrade_recovery(
+                normalized_plugin,
+                target=plugin_target,
+                recovery_root=plugin_recovery_root,
+                dry_run=dry_run,
+            )
+        plugin = _component_with_ownership(
+            normalized_plugin,
+            prior_plugin,
+            preserve_initial_backup=preserve_plugin_backup,
+        )
+        plugin["eligible"] = True
+        plugin["message"] = normalized_plugin["message"]
+
+    payload: Dict[str, object] = {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "product": PRODUCT_NAME,
+        "version": __version__,
+        "installed_at": datetime.now(timezone.utc).isoformat(),
+        "resource_root": str(resources),
+        "user_data_root": str(manifest_path.parent),
+        "codex_home": str(selected_codex_home),
+        "abaqus": {
+            "usable": bool(abaqus.get("usable")),
+            "version": str(abaqus.get("version") or ""),
+            "release_year": year,
+            "safe_plugin_verified": plugin_eligible,
+        },
+        "skill": skill,
+        "plugin": plugin,
+        "manifest_path": str(manifest_path),
+        "dry_run": dry_run,
+    }
+    if not dry_run:
+        try:
+            _write_manifest(manifest_path, payload)
+        except DistributionIntegrationError:
+            _rollback_install(plugin)
+            _rollback_install(skill)
+            raise
+    return payload
+
+
+def _safe_component_from_manifest(
+    manifest: Mapping[str, object], name: str, *, data_root_path: Path
+) -> Mapping[str, object]:
+    component = manifest.get(name)
+    if not isinstance(component, Mapping):
+        raise DistributionIntegrationError("集成清单缺少 {0} 组件。".format(name))
+    target_text = str(component.get("target") or "").strip()
+    if not target_text:
+        raise DistributionIntegrationError("集成清单缺少 {0} 目标。".format(name))
+    target = _lexical_absolute(Path(target_text))
+    if name == "skill":
+        recorded_codex = _lexical_absolute(Path(str(manifest.get("codex_home") or "")))
+        expected = recorded_codex / "skills" / SKILL_DIRECTORY_NAME
+    else:
+        expected = _lexical_absolute(default_plugin_target())
+    if target != expected:
+        raise DistributionIntegrationError(
+            "{0} 目标与清单所属用户不匹配，未更改文件。".format(name)
+        )
+    # 防止通过损坏清单把数据根或其父目录当成组件。
+    if target == data_root_path or target in data_root_path.parents:
+        raise DistributionIntegrationError("集成目标不能覆盖用户数据根。")
+    _assert_no_reparse_path(target, label="{0} 受管目标".format(name))
+    recovery_root = _component_recovery_root(component, target)
+    expected_recovery = data_root_path / "recovery" / name
+    if recovery_root != expected_recovery:
+        raise DistributionIntegrationError(
+            "{0} 恢复区与当前用户数据根不匹配。".format(name)
+        )
+    _valid_backup(target, component.get("backup"), recovery_root)
+    recoveries = component.get("upgrade_recoveries")
+    if recoveries is not None and not isinstance(recoveries, list):
+        raise DistributionIntegrationError("集成清单的升级恢复记录格式无效。")
+    for value in recoveries or []:
+        _valid_backup(target, value, recovery_root, label="upgrade")
+    return component
+
+
+def _component_recovery_root(
+    component: Mapping[str, object], target: Path
+) -> Path:
+    text = str(component.get("recovery_root") or "").strip()
+    if not text:
+        raise DistributionIntegrationError(
+            "旧集成清单未记录隔离恢复区；"
+            "为避免 Codex/Abaqus 重复加载，请先人工确认历史备份。"
+        )
+    recovery_root = _lexical_absolute(Path(text))
+    _assert_no_reparse_path(recovery_root, label="用户恢复路径")
+    if recovery_root == target.parent or target.parent in recovery_root.parents:
+        raise DistributionIntegrationError(
+            "恢复区不能位于 Codex/Abaqus 扫描目录内。"
+        )
+    return recovery_root
+
+
+def _valid_backup(
+    target: Path,
+    value: object,
+    recovery_root: Path,
+    *,
+    label: str = "backup",
+) -> Optional[Path]:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    backup = _lexical_absolute(Path(text))
+    expected_prefix = target.name + ".{0}-".format(label)
+    if backup.parent != recovery_root or not backup.name.startswith(expected_prefix):
+        raise DistributionIntegrationError("恢复副本路径不安全，未更改文件。")
+    _assert_no_reparse_path(backup, label="恢复副本路径")
+    return backup
+
+
+def _remove_component(component: Mapping[str, object]) -> Dict[str, object]:
+    target = _lexical_absolute(Path(str(component["target"])))
+    recovery_root = _component_recovery_root(component, target)
+    backup = _valid_backup(target, component.get("backup"), recovery_root)
+    result: Dict[str, object] = {
+        "target": str(target),
+        "backup": str(backup) if backup is not None else None,
+        "status": "not_managed",
+        "recovery_copy": None,
+    }
+    if not bool(component.get("managed")):
+        return result
+    installed_digest = str(component.get("installed_digest") or "")
+    if target.exists():
+        if not target.is_dir():
+            result["status"] = "preserved_modified"
+            return result
+        try:
+            unchanged = bool(installed_digest) and _directory_digest(target) == installed_digest
+        except DistributionIntegrationError:
+            unchanged = False
+        if not unchanged:
+            result["status"] = "preserved_modified"
+            return result
+        recovery = _next_recovery_path(recovery_root, target, "uninstalled")
+        _move_directory(target, recovery)
+        result["recovery_copy"] = str(recovery)
+    if backup is not None and backup.exists():
+        if backup.is_symlink() or not backup.is_dir() or target.exists():
+            result["status"] = "preserved_backup"
+            return result
+        _move_directory(backup, target)
+        result["status"] = "restored_backup"
+    else:
+        result["status"] = "moved_to_recovery" if result["recovery_copy"] else "already_absent"
+    return result
+
+
+def integration_remove(
+    *, confirmed: bool, data_root: Optional[Path] = None
+) -> Dict[str, object]:
+    """可恢复地移除受管集成；用户改过的目录保持原位。"""
+
+    if not confirmed:
+        raise DistributionIntegrationError("移除集成前需要明确确认。")
+    manifest_path = _manifest_path(data_root)
+    manifest = _read_manifest(manifest_path, required=True)
+    assert manifest is not None
+    data_root_path = _lexical_absolute(manifest_path.parent)
+    if _lexical_absolute(Path(str(manifest.get("user_data_root") or ""))) != data_root_path:
+        raise DistributionIntegrationError("集成清单与当前用户数据根不匹配。")
+    skill = _safe_component_from_manifest(manifest, "skill", data_root_path=data_root_path)
+    plugin = _safe_component_from_manifest(manifest, "plugin", data_root_path=data_root_path)
+
+    # 先完成所有清单/路径验证；再温和停止受管 MCP，
+    # 最后才移动 Skill 和插件。
+    plugin_target = _lexical_absolute(Path(str(plugin["target"])))
+    mcp_home = plugin_target.parent.parent / ".abaqus-mcp"
+    _assert_no_reparse_path(mcp_home, label="Abaqus MCP 用户目录")
+    from abaqus_codex.mcp_setup import (
+        remove_managed_codex_registration,
+        stop_managed_headless_bridge_for_uninstall,
+    )
+
+    headless_bridge = stop_managed_headless_bridge_for_uninstall(target=mcp_home)
+    headless_status = str(headless_bridge.get("status") or "")
+    if headless_status == "stop_not_confirmed" or (
+        headless_status == "stopped" and not bool(headless_bridge.get("stopped"))
+    ):
+        raise DistributionIntegrationError(
+            "本项目管理的 MCP 后台进程尚未确认停止；"
+            "已保留集成清单，请重试卸载或明确选择仅移除核心程序。"
+        )
+
+    mcp_registration = remove_managed_codex_registration(target=mcp_home)
+    if str(mcp_registration.get("status") or "") == "remove_failed":
+        raise DistributionIntegrationError(
+            "本项目管理的 Codex MCP 注册未能移除；"
+            "已保留集成清单，请重试卸载或明确选择仅移除核心程序。"
+        )
+
+    skill_result = _remove_component(skill)
+    plugin_result = _remove_component(plugin)
+    archived_manifest = _next_recovery_path(
+        data_root_path / "recovery" / "manifest", manifest_path, "removed"
+    )
+    _move_directory(manifest_path, archived_manifest)
+    return {
+        "product": PRODUCT_NAME,
+        "removed_at": datetime.now(timezone.utc).isoformat(),
+        "manifest_path": str(manifest_path),
+        "archived_manifest": str(archived_manifest),
+        "skill": skill_result,
+        "plugin": plugin_result,
+        "headless_bridge": headless_bridge,
+        "mcp_registration": mcp_registration,
+    }
+
+
+__all__ = [
+    "DistributionIntegrationError",
+    "MANIFEST_FILENAME",
+    "integration_remove",
+    "integration_setup",
+]

--- a/src/abaqus_codex/mcp_environment.py
+++ b/src/abaqus_codex/mcp_environment.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 from abaqus_codex.mcp_guard import inspect_bridge_status
+from abaqus_codex.paths import project_python_executable
 
 
 def vendor_python_paths(vendor_path: Path) -> List[Path]:
@@ -169,7 +170,7 @@ def verify_local_mcp_import(
     for dependency_mode, environment in attempts:
         try:
             completed = subprocess.run(
-                [sys.executable, "-c", python_code],
+                [str(project_python_executable()), "-c", python_code],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 env=environment,

--- a/src/abaqus_codex/mcp_setup.py
+++ b/src/abaqus_codex/mcp_setup.py
@@ -3,10 +3,10 @@
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -18,12 +18,14 @@ from abaqus_codex.abqpy_environment import (
 )
 from abaqus_codex.environment import inspect_abaqus
 from abaqus_codex.mcp_environment import (
+    _codex_candidates,
     inspect_abaqus_mcp,
     parse_abaqus_mcp_names,
     query_codex_mcp_list,
     vendor_python_paths,
 )
 from abaqus_codex.mcp_guard import MANAGED_GUARD_MARKER
+from abaqus_codex.paths import is_private_runtime, project_python_executable
 
 
 MCP_REPOSITORY = "https://github.com/Cai-aa/abaqus-mcp.git"
@@ -34,6 +36,247 @@ MCP_SERVER_NAME = "abaqus-mcp-server"
 
 class McpSetupError(RuntimeError):
     """表示 MCP 安装或注册没有安全完成。"""
+
+
+def _same_lexical_path(value: object, expected: Path) -> bool:
+    """比较命令配置中的绝对路径，不解析链接或访问目标文件。"""
+
+    if not isinstance(value, str) or not value.strip():
+        return False
+    actual_text = os.path.normcase(
+        os.path.abspath(os.path.expanduser(value.strip()))
+    )
+    expected_text = os.path.normcase(
+        os.path.abspath(os.path.expanduser(os.fspath(expected)))
+    )
+    return actual_text == expected_text
+
+
+def _managed_registration_matches(
+    payload: object, target: Path, executable: Path
+) -> bool:
+    """仅识别本安装版生成、且没有被用户改动的 stdio 注册。"""
+
+    if not isinstance(payload, dict):
+        return False
+    transport = payload.get("transport")
+    if not isinstance(transport, dict):
+        return False
+    if transport.get("type") != "stdio":
+        return False
+    if not _same_lexical_path(transport.get("command"), executable):
+        return False
+
+    arguments = transport.get("args")
+    expected_guard = target / "mcp_guard.py"
+    if (
+        not isinstance(arguments, list)
+        or len(arguments) != 1
+        or not _same_lexical_path(arguments[0], expected_guard)
+    ):
+        return False
+
+    environment = transport.get("env")
+    if not isinstance(environment, dict):
+        return False
+    if not _same_lexical_path(environment.get("ABAQUS_MCP_HOME"), target):
+        return False
+
+    # 本项目注册时只写入这两个环境变量。额外变量、工作目录或继承变量
+    # 都可能是用户后续修改，因此宁可留下失效注册，也绝不擅自删除。
+    expected_python_path = os.pathsep.join(
+        str(path) for path in vendor_python_paths(target / "vendor")
+    )
+    if set(environment) != {"ABAQUS_MCP_HOME", "PYTHONPATH"}:
+        return False
+    if environment.get("PYTHONPATH") != expected_python_path:
+        return False
+    if transport.get("cwd") not in (None, ""):
+        return False
+    if transport.get("env_vars") not in (None, []):
+        return False
+    return True
+
+
+def remove_managed_codex_registration(
+    target: Optional[Path] = None, timeout_seconds: int = 15
+) -> Dict[str, object]:
+    """安全移除当前运行时拥有的 MCP 注册；无法证明所有权时保持原样。"""
+
+    install_target = (target or (Path.home() / ".abaqus-mcp")).resolve()
+    result: Dict[str, object] = {
+        "status": "cli_unavailable",
+        "removed": False,
+        "target": str(install_target),
+        "codex_cli": None,
+        "message": "没有找到 Codex CLI；未更改 MCP 注册。",
+    }
+    candidates = _codex_candidates()
+    if not candidates:
+        return result
+
+    query_failures: List[str] = []
+    for candidate in candidates:
+        command = [
+            str(candidate),
+            "mcp",
+            "get",
+            MCP_SERVER_NAME,
+            "--json",
+        ]
+        try:
+            completed = subprocess.run(
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                timeout=timeout_seconds,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as error:
+            query_failures.append("{0}: {1}".format(candidate, error))
+            continue
+        if completed.returncode != 0:
+            # Codex 对“不存在”和其他读取失败均返回非零；两种情况都必须
+            # 保持不变，且不依赖可能随版本/语言变化的错误文字。
+            query_failures.append(
+                "{0}: 退出码 {1}".format(candidate, completed.returncode)
+            )
+            continue
+        try:
+            payload = json.loads(
+                completed.stdout.decode("utf-8", errors="strict")
+            )
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            query_failures.append("{0}: JSON 无效（{1}）".format(candidate, error))
+            continue
+
+        result["codex_cli"] = str(candidate)
+        if not _managed_registration_matches(
+            payload, install_target, project_python_executable()
+        ):
+            result.update(
+                {
+                    "status": "preserved_unmanaged",
+                    "message": (
+                        "MCP 注册不是当前安装版的原始受管配置；已保留。"
+                    ),
+                }
+            )
+            return result
+        try:
+            _run_command(
+                [str(candidate), "mcp", "remove", MCP_SERVER_NAME],
+                timeout_seconds=timeout_seconds,
+            )
+        except McpSetupError as error:
+            result.update(
+                {
+                    "status": "remove_failed",
+                    "message": "受管 MCP 注册未能移除；已停止清理：{0}".format(
+                        error
+                    ),
+                }
+            )
+            return result
+        result.update(
+            {
+                "status": "removed",
+                "removed": True,
+                "message": "已移除当前安装版创建的 Abaqus MCP 注册。",
+            }
+        )
+        return result
+
+    result.update(
+        {
+            "status": "not_registered_or_unreadable",
+            "message": "未读取到 Abaqus MCP 注册；未更改任何配置。",
+            "query_failures": query_failures,
+        }
+    )
+    return result
+
+
+def stop_managed_headless_bridge_for_uninstall(
+    target: Optional[Path] = None, timeout_seconds: int = 20
+) -> Dict[str, object]:
+    """仅向本项目标记的 headless bridge 发停止信号，绝不强杀进程。"""
+
+    from abaqus_codex.mcp_headless import (
+        HEADLESS_PID_NAME,
+        HEADLESS_SCRIPT_NAME,
+        MANAGED_HEADLESS_MARKER,
+        McpHeadlessError,
+        inspect_headless_bridge,
+        stop_headless_bridge,
+    )
+
+    install_target = (target or (Path.home() / ".abaqus-mcp")).resolve()
+    script = install_target / HEADLESS_SCRIPT_NAME
+    launcher_path = install_target / HEADLESS_PID_NAME
+    base: Dict[str, object] = {
+        "status": "not_running",
+        "stopped": True,
+        "target": str(install_target),
+        "message": "没有本项目管理的 headless bridge 需要停止。",
+    }
+    try:
+        state = inspect_headless_bridge(install_target)
+    except (OSError, ValueError) as error:
+        base.update(
+            {
+                "status": "inspection_failed",
+                "stopped": False,
+                "message": "无法确认 headless bridge 所有权；未发送停止信号：{0}".format(
+                    error
+                ),
+            }
+        )
+        return base
+    if not state.get("managed_process_running"):
+        return base
+
+    try:
+        script_text = script.read_text(encoding="utf-8", errors="replace")
+        launcher = json.loads(launcher_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, UnicodeDecodeError, json.JSONDecodeError):
+        launcher = None
+        script_text = ""
+    if (
+        MANAGED_HEADLESS_MARKER not in script_text
+        or not isinstance(launcher, dict)
+        or not _same_lexical_path(launcher.get("script"), script)
+    ):
+        base.update(
+            {
+                "status": "preserved_unmanaged",
+                "stopped": False,
+                "message": "后台进程缺少本项目所有权标记；未发送停止信号。",
+            }
+        )
+        return base
+
+    try:
+        after = stop_headless_bridge(
+            install_target, timeout_seconds=timeout_seconds
+        )
+    except McpHeadlessError as error:
+        base.update(
+            {
+                "status": "stop_not_confirmed",
+                "stopped": False,
+                "message": str(error),
+            }
+        )
+        return base
+    base.update(
+        {
+            "status": "stopped",
+            "stopped": not bool(after.get("managed_process_running")),
+            "message": "已请求本项目 headless bridge 自行停止；未强杀进程。",
+        }
+    )
+    return base
 
 
 def _run_command(
@@ -94,9 +337,12 @@ def _ensure_dependencies(target: Path) -> str:
         return "MCP Python 依赖已存在，未重复安装。"
 
     vendor.mkdir(parents=True, exist_ok=True)
+    python_command = [str(project_python_executable())]
+    if is_private_runtime():
+        python_command.append("-I")
     _run_command(
-        [
-            sys.executable,
+        python_command
+        + [
             "-m",
             "pip",
             "install",
@@ -172,7 +418,7 @@ def _registration_command(codex_cli: Path, target: Path, entry: Path) -> List[st
         "--env",
         "PYTHONPATH={0}".format(python_path),
         "--",
-        sys.executable,
+        str(project_python_executable()),
         str(entry),
     ]
 

--- a/src/abaqus_codex/onboarding.py
+++ b/src/abaqus_codex/onboarding.py
@@ -7,7 +7,6 @@ import os
 import platform
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 from typing import Dict, Optional
 from urllib.error import HTTPError, URLError
@@ -19,6 +18,7 @@ from abaqus_codex.abqpy_environment import (
     recommended_abqpy_requirement,
 )
 from abaqus_codex.doctor import inspect_environment
+from abaqus_codex.paths import project_python_executable
 
 
 ZOTERO_BASE_URL = "http://127.0.0.1:23119"
@@ -308,7 +308,7 @@ def inspect_onboarding() -> Dict[str, object]:
     project_python = {
         "usable": True,
         "version": platform.python_version(),
-        "executable": sys.executable,
+        "executable": str(project_python_executable()),
         "message": "项目 Python 可以运行当前体检。",
     }
 

--- a/src/abaqus_codex/paths.py
+++ b/src/abaqus_codex/paths.py
@@ -1,0 +1,198 @@
+# -*- coding: utf-8 -*-
+"""区分随程序发布的只读资源与当前用户的可写数据。"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Iterable, Optional
+
+
+RESOURCE_ROOT_ENV = "ABAQUS_CODEX_INSTALL_ROOT"
+USER_DATA_ROOT_ENV = "ABAQUS_CODEX_USER_DATA_ROOT"
+RESOURCE_MARKERS = ("configs", "skills", "abaqus_plugins")
+
+
+def _absolute_path(value: object) -> Optional[Path]:
+    """把非空路径转成绝对路径，不要求路径已经存在。"""
+
+    text = str(value or "").strip()
+    if not text:
+        return None
+    return Path(text).expanduser().resolve(strict=False)
+
+
+def _has_resource_markers(path: Path) -> bool:
+    """只有同时包含三类发布资源时，才把目录当成安装根。"""
+
+    try:
+        return path.is_dir() and all((path / name).is_dir() for name in RESOURCE_MARKERS)
+    except OSError:
+        return False
+
+
+def _candidate_ancestors(start: Path) -> Iterable[Path]:
+    """从一个文件或目录向上枚举，并保持稳定顺序。"""
+
+    current = start if start.is_dir() else start.parent
+    yield current
+    yield from current.parents
+
+
+def resource_root() -> Path:
+    """返回只读发布资源根目录。
+
+    安装版的固定布局是 ``{app}\\runtime\\Lib\\site-packages`` 中安装
+    Python 包，而 ``configs``、``skills`` 和 ``abaqus_plugins`` 位于
+    ``{app}``。源码模式则从 ``repo/src/abaqus_codex`` 向上找到仓库根。
+    显式环境变量便于安装器和离线测试指定资源；若指定了却
+    不完整，立即报错，不再猜测另一份资源。
+    """
+
+    module_start = Path(__file__).resolve()
+    executable = _absolute_path(sys.executable)
+
+    def first_root(start: Optional[Path]) -> Optional[Path]:
+        if start is None:
+            return None
+        for candidate in _candidate_ancestors(start):
+            if _has_resource_markers(candidate):
+                return candidate
+        return None
+
+    # 官方自包含布局中，包与解释器同时位于 {app}/runtime。
+    # 此时必须优先使用自身完整资源，不允许残留环境变量劫持。
+    module_root = first_root(module_start)
+    executable_root = first_root(executable)
+    if module_root is not None and executable_root == module_root and executable is not None:
+        try:
+            executable_relative = executable.relative_to(module_root)
+        except ValueError:
+            executable_relative = None
+        if executable_relative is not None and executable_relative.parts:
+            if executable_relative.parts[0].lower() == "runtime":
+                return module_root
+
+    explicit = _absolute_path(os.environ.get(RESOURCE_ROOT_ENV))
+    if explicit is not None:
+        if not _has_resource_markers(explicit):
+            raise RuntimeError(
+                "{0} 指向的资源根不完整：{1}".format(
+                    RESOURCE_ROOT_ENV, explicit
+                )
+            )
+        return explicit
+
+    starts: list[Path] = [module_start]
+    if executable is not None:
+        starts.append(executable)
+    frozen_root = _absolute_path(getattr(sys, "_MEIPASS", None))
+    if frozen_root is not None:
+        starts.insert(0, frozen_root)
+
+    seen: set[Path] = set()
+    for start in starts:
+        for candidate in _candidate_ancestors(start):
+            if candidate in seen:
+                continue
+            seen.add(candidate)
+            if _has_resource_markers(candidate):
+                return candidate
+
+    raise RuntimeError(
+        "未找到完整的 Abaqus Codex Assistant 资源；"
+        "请修复安装或设置 {0}。".format(RESOURCE_ROOT_ENV)
+    )
+
+
+def user_data_root(*, create: bool = False) -> Path:
+    """返回当前用户的可写数据根目录。
+
+    默认为 ``%LOCALAPPDATA%\\AbaqusCodexAssistant``；测试或便携式部署
+    可用 ``ABAQUS_CODEX_USER_DATA_ROOT`` 显式覆盖。本函数不会把
+    发布目录当作可写目录。
+    """
+
+    root = _absolute_path(os.environ.get(USER_DATA_ROOT_ENV))
+    if root is None:
+        local_data = _absolute_path(os.environ.get("LOCALAPPDATA"))
+        if local_data is None:
+            # 非 Windows 的测试和开发环境仍有可预期的用户级回退。
+            local_data = Path.home().resolve(strict=False) / ".local" / "share"
+        root = local_data / "AbaqusCodexAssistant"
+    if create:
+        root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def is_private_runtime() -> bool:
+    """当前进程是否由 Windows 安装版自带的 Python 启动。"""
+
+    try:
+        expected = (resource_root() / "runtime").resolve(strict=False)
+        executable_parent = Path(sys.executable).resolve(strict=False).parent
+    except (OSError, RuntimeError):
+        return False
+    return executable_parent == expected
+
+
+def user_python_packages(*, create: bool = False) -> Path:
+    """返回安装版可选 Python 包的用户级目录。"""
+
+    target = user_data_root(create=create) / "python-packages"
+    if create:
+        target.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+def activate_user_python_packages(*, create: bool = False) -> Optional[Path]:
+    """仅在私有运行时中启用用户级可选包，并返回其路径。"""
+
+    if not is_private_runtime():
+        return None
+    target = user_python_packages(create=create)
+    if not target.is_dir():
+        return None
+    text = str(target)
+    if text not in sys.path:
+        sys.path.insert(0, text)
+    return target
+
+
+def project_python_executable() -> Path:
+    """返回适合 CLI、pip 和 MCP stdio 的项目 Python。"""
+
+    current = Path(sys.executable).resolve(strict=False)
+    if is_private_runtime():
+        console_python = resource_root() / "runtime" / "python.exe"
+        if console_python.is_file():
+            return console_python.resolve(strict=False)
+    return current
+
+
+def codex_home(explicit: Optional[Path] = None) -> Path:
+    """返回 Codex 用户目录，支持显式值和 ``CODEX_HOME``。"""
+
+    selected = _absolute_path(explicit)
+    if selected is None:
+        selected = _absolute_path(os.environ.get("CODEX_HOME"))
+    if selected is not None:
+        return selected
+    user_profile = _absolute_path(os.environ.get("USERPROFILE"))
+    if user_profile is None:
+        user_profile = Path.home().resolve(strict=False)
+    return user_profile / ".codex"
+
+
+__all__ = [
+    "RESOURCE_ROOT_ENV",
+    "USER_DATA_ROOT_ENV",
+    "activate_user_python_packages",
+    "codex_home",
+    "is_private_runtime",
+    "project_python_executable",
+    "resource_root",
+    "user_data_root",
+    "user_python_packages",
+]

--- a/src/abaqus_codex/safe_action_setup.py
+++ b/src/abaqus_codex/safe_action_setup.py
@@ -13,6 +13,7 @@ from typing import Dict, Optional
 
 from abaqus_codex.abqpy_environment import parse_release_year
 from abaqus_codex.environment import inspect_abaqus
+from abaqus_codex.paths import resource_root, user_data_root
 
 
 # 第一版只面向维护者已经真机验证的 Abaqus 2021。
@@ -30,11 +31,68 @@ class SafeActionSetupError(RuntimeError):
     """表示安全动作插件没有完成预检或安装。"""
 
 
-def default_plugin_source() -> Path:
-    """返回源码仓库内随项目维护的插件目录。"""
+def _lexical_absolute(path: Path) -> Path:
+    """不解析 symlink/junction 地转为绝对路径。"""
 
-    project_root = Path(__file__).resolve().parents[2]
-    return project_root / "abaqus_plugins" / PLUGIN_DIRECTORY_NAME
+    return Path(os.path.abspath(os.path.expanduser(os.fspath(path))))
+
+
+def _is_reparse_point(path: Path) -> bool:
+    try:
+        if path.is_symlink():
+            return True
+    except OSError:
+        return True
+    is_junction = getattr(path, "is_junction", None)
+    if callable(is_junction):
+        try:
+            if is_junction():
+                return True
+        except OSError:
+            return True
+    try:
+        attributes = int(getattr(path.lstat(), "st_file_attributes", 0) or 0)
+    except FileNotFoundError:
+        return False
+    except OSError:
+        return True
+    return bool(attributes & 0x0400)
+
+
+def _assert_no_reparse_path(path: Path, label: str) -> None:
+    current = _lexical_absolute(path)
+    while True:
+        if _is_reparse_point(current):
+            raise SafeActionSetupError(
+                "{0}包含符号链接或 Windows 联接点：{1}".format(label, current)
+            )
+        if current.parent == current:
+            return
+        current = current.parent
+
+
+def _nearest_existing_path(path: Path) -> Path:
+    current = _lexical_absolute(path)
+    while not current.exists() and current.parent != current:
+        current = current.parent
+    return current
+
+
+def _same_storage_volume(left: Path, right: Path) -> bool:
+    left_drive = os.path.normcase(os.path.splitdrive(str(_lexical_absolute(left)))[0])
+    right_drive = os.path.normcase(os.path.splitdrive(str(_lexical_absolute(right)))[0])
+    if left_drive or right_drive:
+        return bool(left_drive and left_drive == right_drive)
+    try:
+        return _nearest_existing_path(left).stat().st_dev == _nearest_existing_path(right).stat().st_dev
+    except OSError:
+        return False
+
+
+def default_plugin_source() -> Path:
+    """返回安装资源内随项目维护的插件目录。"""
+
+    return resource_root() / "abaqus_plugins" / PLUGIN_DIRECTORY_NAME
 
 
 def default_plugin_target() -> Path:
@@ -62,27 +120,41 @@ def _file_digest(path: Path) -> str:
 def _directory_manifest(root: Path) -> Dict[str, str]:
     """生成不跟随符号链接的目录清单，用于判断两份插件是否相同。"""
 
-    if root.is_symlink():
-        raise SafeActionSetupError("插件目录不能是符号链接：{0}".format(root))
+    if _is_reparse_point(root):
+        raise SafeActionSetupError(
+            "插件目录不能是符号链接或 Windows 联接点：{0}".format(root)
+        )
     if not root.is_dir():
         raise SafeActionSetupError("没有找到有效的插件目录：{0}".format(root))
 
     manifest: Dict[str, str] = {}
-    for path in sorted(root.rglob("*"), key=lambda item: item.as_posix()):
-        relative = path.relative_to(root).as_posix()
-        if path.is_symlink():
+    def visit(directory: Path) -> None:
+        try:
+            with os.scandir(directory) as scan:
+                children = sorted(scan, key=lambda item: item.name)
+        except OSError as error:
             raise SafeActionSetupError(
-                "插件目录中含有符号链接，已停止安装：{0}".format(relative)
-            )
-        if path.is_dir():
-            # 记录空目录，避免把结构不同的插件误判为完全相同。
-            manifest["目录:{0}".format(relative)] = ""
-        elif path.is_file():
-            manifest["文件:{0}".format(relative)] = _file_digest(path)
-        else:
-            raise SafeActionSetupError(
-                "插件目录中含有不支持的文件类型：{0}".format(relative)
-            )
+                "无法安全读取插件目录：{0}".format(directory)
+            ) from error
+        for child in children:
+            path = directory / child.name
+            relative = path.relative_to(root).as_posix()
+            if _is_reparse_point(path):
+                raise SafeActionSetupError(
+                    "插件目录中含有符号链接或 Windows 联接点，"
+                    "已停止安装：{0}".format(relative)
+                )
+            if child.is_dir(follow_symlinks=False):
+                manifest["目录:{0}".format(relative)] = ""
+                visit(path)
+            elif child.is_file(follow_symlinks=False):
+                manifest["文件:{0}".format(relative)] = _file_digest(path)
+            else:
+                raise SafeActionSetupError(
+                    "插件目录中含有不支持的文件类型：{0}".format(relative)
+                )
+
+    visit(root)
     return manifest
 
 
@@ -98,22 +170,34 @@ def _validate_source(source: Path) -> Dict[str, str]:
     return manifest
 
 
-def _next_backup_path(target: Path) -> Path:
-    """生成带时间戳且不会覆盖旧备份的同级目录名。"""
+def _next_backup_path(target: Path, backup_root: Path) -> Path:
+    """在用户数据恢复区生成备份，避免 Abaqus 重复扫描。"""
 
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-    base = target.with_name("{0}.backup-{1}".format(target.name, timestamp))
+    base = backup_root / "{0}.backup-{1}".format(target.name, timestamp)
     if not base.exists() and not base.is_symlink():
         return base
 
     # 同一秒内多次安装时增加序号，任何已有备份都不会被覆盖。
     for index in range(1, 1000):
-        candidate = target.with_name(
-            "{0}.backup-{1}-{2:03d}".format(target.name, timestamp, index)
+        candidate = backup_root / "{0}.backup-{1}-{2:03d}".format(
+            target.name, timestamp, index
         )
         if not candidate.exists() and not candidate.is_symlink():
             return candidate
     raise SafeActionSetupError("同名备份过多，请先人工整理插件目录。")
+
+
+def _next_recovery_path(target: Path, backup_root: Path, label: str) -> Path:
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    base = backup_root / "{0}.{1}-{2}".format(target.name, label, timestamp)
+    if not base.exists() and not base.is_symlink():
+        return base
+    for index in range(1, 1000):
+        candidate = backup_root / "{0}-{1:03d}".format(base.name, index)
+        if not candidate.exists() and not candidate.is_symlink():
+            return candidate
+    raise SafeActionSetupError("同名恢复副本过多，请先人工整理。")
 
 
 def _new_staging_path(target: Path) -> Path:
@@ -149,6 +233,7 @@ def setup_safe_action_plugin(
     confirmed: bool,
     target: Optional[Path] = None,
     source: Optional[Path] = None,
+    backup_root: Optional[Path] = None,
     dry_run: bool = False,
 ) -> Dict[str, object]:
     """预检并安装插件；dry-run 只返回计划，不创建任何文件。"""
@@ -161,20 +246,39 @@ def setup_safe_action_plugin(
     abaqus = _preflight_abaqus_2021()
     source_path = Path(source) if source is not None else default_plugin_source()
     target_path = Path(target) if target is not None else default_plugin_target()
+    backup_root_path = (
+        Path(backup_root)
+        if backup_root is not None
+        else user_data_root() / "recovery" / "plugin"
+    )
 
-    # 先解析绝对路径，避免把插件误复制到自己内部。
-    try:
-        source_path = source_path.resolve(strict=True)
-        target_resolved = target_path.resolve(strict=False)
-    except OSError as error:
-        raise SafeActionSetupError("无法解析插件路径：{0}".format(error)) from error
-    if source_path == target_resolved:
-        raise SafeActionSetupError("插件源码目录和安装目录不能相同。")
-    if target_path.is_symlink():
-        raise SafeActionSetupError("安装目录不能是符号链接：{0}".format(target_path))
+    source_path = _lexical_absolute(source_path)
+    target_path = _lexical_absolute(target_path)
+    backup_root_path = _lexical_absolute(backup_root_path)
+    _assert_no_reparse_path(source_path, "插件资源路径")
+    _assert_no_reparse_path(target_path, "插件安装路径")
+    _assert_no_reparse_path(backup_root_path, "插件恢复路径")
+    if (
+        source_path == target_path
+        or source_path in target_path.parents
+        or target_path in source_path.parents
+    ):
+        raise SafeActionSetupError(
+            "插件资源和安装目录不能相同、互为父目录或子目录。"
+        )
+    if target_path.parent in backup_root_path.parents or backup_root_path == target_path.parent:
+        raise SafeActionSetupError("插件恢复区不能位于 Abaqus 插件扫描目录内。")
+    if not _same_storage_volume(target_path.parent, backup_root_path):
+        raise SafeActionSetupError(
+            "插件目标和恢复区不在同一磁盘；已在复制前停止。"
+        )
 
     source_manifest = _validate_source(source_path)
     target_exists = target_path.exists()
+    if target_exists and not target_path.is_dir():
+        raise SafeActionSetupError(
+            "插件目标已存在且不是目录；为保证可完整恢复，未更改该文件。"
+        )
     target_matches = False
     if target_exists and target_path.is_dir():
         target_matches = _directory_manifest(target_path) == source_manifest
@@ -190,7 +294,9 @@ def setup_safe_action_plugin(
             "message": "安全动作插件已是当前版本，未重复安装。",
         }
 
-    backup_path = _next_backup_path(target_path) if target_exists else None
+    backup_path = (
+        _next_backup_path(target_path, backup_root_path) if target_exists else None
+    )
     if dry_run:
         message = (
             "演练完成：现有插件将先备份，再安装项目版本。"
@@ -210,11 +316,24 @@ def setup_safe_action_plugin(
     staging_path = _new_staging_path(target_path)
     try:
         target_path.parent.mkdir(parents=True, exist_ok=True)
+        if target_exists:
+            backup_root_path.mkdir(parents=True, exist_ok=True)
+        _assert_no_reparse_path(target_path.parent, "插件安装父路径")
+        if target_exists:
+            _assert_no_reparse_path(backup_root_path, "插件恢复路径")
         # 先完整复制到同级临时目录，复制失败时不碰原插件。
         shutil.copytree(source_path, staging_path, copy_function=shutil.copy2)
         if _directory_manifest(staging_path) != source_manifest:
             raise SafeActionSetupError("临时插件副本校验失败，原插件未更改。")
-    except (OSError, shutil.Error) as error:
+    except (OSError, shutil.Error, SafeActionSetupError) as error:
+        if staging_path.exists() and not staging_path.is_symlink():
+            try:
+                backup_root_path.mkdir(parents=True, exist_ok=True)
+                staging_path.replace(
+                    _next_recovery_path(target_path, backup_root_path, "failed-copy")
+                )
+            except (OSError, SafeActionSetupError):
+                pass
         raise SafeActionSetupError(
             "复制插件失败，原插件未更改：{0}".format(error)
         ) from error
@@ -223,7 +342,7 @@ def setup_safe_action_plugin(
     try:
         if target_exists:
             assert backup_path is not None
-            # 使用同级重命名保存完整旧目录，不递归删除任何用户文件。
+            _assert_no_reparse_path(target_path, "插件安装路径")
             target_path.replace(backup_path)
             original_was_backed_up = True
         staging_path.replace(target_path)
@@ -236,7 +355,15 @@ def setup_safe_action_plugin(
         ):
             try:
                 backup_path.replace(target_path)
-            except OSError:
+            except (OSError, SafeActionSetupError):
+                pass
+        if staging_path.exists() and not staging_path.is_symlink():
+            try:
+                backup_root_path.mkdir(parents=True, exist_ok=True)
+                staging_path.replace(
+                    _next_recovery_path(target_path, backup_root_path, "failed-switch")
+                )
+            except (OSError, SafeActionSetupError):
                 pass
         raise SafeActionSetupError(
             "切换插件目录失败；没有递归删除任何目录：{0}".format(error)

--- a/src/abaqus_codex/workflow.py
+++ b/src/abaqus_codex/workflow.py
@@ -21,6 +21,10 @@ from abaqus_codex.abqpy_environment import (
 )
 from abaqus_codex.configuration import load_config, write_json
 from abaqus_codex.environment import inspect_abaqus
+from abaqus_codex.paths import (
+    activate_user_python_packages,
+    project_python_executable,
+)
 from abaqus_codex.report import write_chinese_report
 from abaqus_codex.user_subroutine import prepare_user_subroutine
 
@@ -39,7 +43,7 @@ def find_abqpy_command() -> Optional[Path]:
     """优先寻找当前虚拟环境中的 abqpy，再检查系统 PATH。"""
 
     script_name = "abqpy.exe" if sys.platform == "win32" else "abqpy"
-    local_command = Path(sys.executable).resolve().parent / script_name
+    local_command = project_python_executable().parent / script_name
     if local_command.is_file():
         return local_command
 
@@ -53,7 +57,7 @@ def build_abqpy_command_prefix() -> Optional[list[str]]:
     # Windows 的 console_scripts 启动器会记录安装时的绝对路径；项目移动后
     # 直接运行 abqpy.exe 可能失效，因此优先由当前解释器启动同一模块。
     if importlib.util.find_spec("abqpy") is not None:
-        return [str(Path(sys.executable).resolve()), "-m", "abqpy"]
+        return [str(project_python_executable()), "-m", "abqpy"]
     command = find_abqpy_command()
     return [str(command)] if command is not None else None
 
@@ -172,6 +176,13 @@ def run_analysis(
         # abqpy 官方支持用该环境变量指定 Abaqus 命令，确保检查和启动为同一版本。
         abaqus_environment = os.environ.copy()
         abaqus_environment["ABAQUS_BAT_PATH"] = str(abaqus["command"])
+        package_target = activate_user_python_packages()
+        if package_target is not None:
+            old_python_path = abaqus_environment.get("PYTHONPATH", "")
+            python_paths = [str(package_target)]
+            if old_python_path:
+                python_paths.append(old_python_path)
+            abaqus_environment["PYTHONPATH"] = os.pathsep.join(python_paths)
         completed = subprocess.run(
             command,
             cwd=work_dir,

--- a/tests/test_abaqus_2021_plugin_shell.py
+++ b/tests/test_abaqus_2021_plugin_shell.py
@@ -33,7 +33,7 @@ class Abaqus2021PluginShellTests(unittest.TestCase):
         source = read_plugin_source("ai_modeling_assistant_plugin.py")
         self.assertIn("registerGuiMenuButton", source)
         self.assertIn("AI 中文建模助手", source)
-        self.assertIn('version="0.2.1"', source)
+        self.assertIn('version="0.2.2"', source)
         self.assertNotIn("kernelInitString", source)
         self.assertNotIn("AFXGuiCommand", source)
 

--- a/tests/test_abqpy_setup.py
+++ b/tests/test_abqpy_setup.py
@@ -13,6 +13,7 @@ from abaqus_codex.abqpy_setup import (
     build_install_command,
     setup_abqpy,
 )
+from abaqus_codex.paths import project_python_executable
 
 
 def usable_abaqus(version: str):
@@ -54,7 +55,10 @@ class AbqpySetupSafetyTests(unittest.TestCase):
         )
         command = build_install_command("abqpy==2025.*", target=target)
 
-        self.assertEqual(command[:4], [sys.executable, "-I", "-m", "pip"])
+        self.assertEqual(
+            command[:4],
+            [str(project_python_executable()), "-I", "-m", "pip"],
+        )
         self.assertEqual(command[-3:], ["--target", str(target), "abqpy==2025.*"])
 
     def test_source_install_command_preserves_existing_python_environment(self):
@@ -62,7 +66,10 @@ class AbqpySetupSafetyTests(unittest.TestCase):
 
         command = build_install_command("abqpy==2021.*")
 
-        self.assertEqual(command[:4], [sys.executable, "-m", "pip", "install"])
+        self.assertEqual(
+            command[:4],
+            [str(project_python_executable()), "-m", "pip", "install"],
+        )
         self.assertNotIn("-I", command)
         self.assertNotIn("--target", command)
 
@@ -135,7 +142,13 @@ class AbqpySetupSafetyTests(unittest.TestCase):
                 command = install_mock.call_args.args[0]
                 self.assertEqual(command[-1], expected_requirement)
                 self.assertEqual(
-                    command[:4], [sys.executable, "-m", "pip", "install"]
+                    command[:4],
+                    [
+                        str(project_python_executable()),
+                        "-m",
+                        "pip",
+                        "install",
+                    ],
                 )
                 self.assertEqual(
                     inspect_abqpy_mock.call_args_list,

--- a/tests/test_abqpy_setup.py
+++ b/tests/test_abqpy_setup.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 
 import sys
 import unittest
+from pathlib import Path
 from unittest.mock import call, patch
 
-from abaqus_codex.abqpy_setup import AbqpySetupError, setup_abqpy
+from abaqus_codex.abqpy_setup import (
+    AbqpySetupError,
+    build_install_command,
+    setup_abqpy,
+)
 
 
 def usable_abaqus(version: str):
@@ -40,6 +45,26 @@ def abqpy_result(abaqus_version: str, version=None, usable=False):
 
 class AbqpySetupSafetyTests(unittest.TestCase):
     """确认安装只能在明确授权和可靠年份检测后进行。"""
+
+    def test_private_runtime_install_command_uses_explicit_user_target(self):
+        """安装版可选依赖不得写进由 Setup 管理的 runtime。"""
+
+        target = Path(
+            r"C:\Users\tester\AppData\Local\AbaqusCodexAssistant\python-packages"
+        )
+        command = build_install_command("abqpy==2025.*", target=target)
+
+        self.assertEqual(command[:4], [sys.executable, "-I", "-m", "pip"])
+        self.assertEqual(command[-3:], ["--target", str(target), "abqpy==2025.*"])
+
+    def test_source_install_command_preserves_existing_python_environment(self):
+        """源码安装不使用用户包目录，命令形式保持兼容。"""
+
+        command = build_install_command("abqpy==2021.*")
+
+        self.assertEqual(command[:4], [sys.executable, "-m", "pip", "install"])
+        self.assertNotIn("-I", command)
+        self.assertNotIn("--target", command)
 
     @patch("abaqus_codex.abqpy_setup._run_install")
     @patch("abaqus_codex.abqpy_setup.inspect_abqpy")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -119,5 +119,76 @@ class McpHeadlessCommandRoutingTests(unittest.TestCase):
         print_mock.assert_called_once_with({"running": True})
 
 
+class DistributionIntegrationCommandTests(unittest.TestCase):
+    """确认自包含安装器只通过固定的用户集成边界写入。"""
+
+    @patch("abaqus_codex.distribution_integration.integration_setup")
+    def test_setup_forwards_confirmation_and_custom_codex_home(self, setup_mock):
+        setup_mock.return_value = {
+            "skill": {"target": "C:/Codex/skills/abaqus-modeling-guide"},
+            "plugin": {"message": "已跳过。"},
+            "manifest_path": "C:/Data/integration-manifest.json",
+            "dry_run": False,
+        }
+        output = io.StringIO()
+        with redirect_stdout(output):
+            exit_code = main(
+                [
+                    "integration-setup",
+                    "--yes",
+                    "--codex-home",
+                    "C:/Codex",
+                    "--data-root",
+                    "C:/Data",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        setup_mock.assert_called_once_with(
+            confirmed=True,
+            codex_home_path=Path("C:/Codex"),
+            data_root=Path("C:/Data"),
+            dry_run=False,
+        )
+        self.assertIn("用户集成清单", output.getvalue())
+
+    @patch("abaqus_codex.distribution_integration.integration_remove")
+    def test_remove_requires_explicit_yes_and_reports_recoverable_status(
+        self, remove_mock
+    ):
+        remove_mock.return_value = {
+            "skill": {"status": "restored_backup"},
+            "plugin": {"status": "not_managed"},
+        }
+        output = io.StringIO()
+        with redirect_stdout(output):
+            exit_code = main(["integration-remove", "--yes"])
+
+        self.assertEqual(exit_code, 0)
+        remove_mock.assert_called_once_with(confirmed=True, data_root=None)
+        self.assertIn("restored_backup", output.getvalue())
+
+    @patch("abaqus_codex.distribution_integration.integration_remove")
+    @patch("abaqus_codex.cli.resource_root", side_effect=RuntimeError("资源损坏"))
+    def test_remove_still_runs_when_installed_resources_are_damaged(
+        self, resource_root_mock, remove_mock
+    ):
+        """卸载清理不能因只读发布资源缺失而连参数都无法解析。"""
+
+        remove_mock.return_value = {
+            "skill": {"status": "moved_to_recovery"},
+            "plugin": {"status": "not_managed"},
+        }
+        exit_code = main(
+            ["integration-remove", "--yes", "--data-root", "C:/Data"]
+        )
+
+        self.assertEqual(exit_code, 0)
+        resource_root_mock.assert_not_called()
+        remove_mock.assert_called_once_with(
+            confirmed=True, data_root=Path("C:/Data")
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_desktop_assistant.py
+++ b/tests/test_desktop_assistant.py
@@ -73,12 +73,40 @@ class TkRuntimeDiscoveryTests(unittest.TestCase):
             environment = {}
 
             configured = _configure_tk_runtime(
-                candidate_roots=[root], environment=environment
+                candidate_roots=[root],
+                environment=environment,
+                working_directory=root,
             )
 
             self.assertTrue(configured)
-            self.assertEqual(environment["TCL_LIBRARY"], str(tcl_directory))
-            self.assertEqual(environment["TK_LIBRARY"], str(tk_directory))
+            self.assertEqual(environment["TCL_LIBRARY"], "tcl8.6")
+            self.assertEqual(environment["TK_LIBRARY"], "tk8.6")
+
+    def test_non_ascii_install_uses_working_directory_relative_paths(self):
+        """中文安装根不能被写入 Tcl 绝对路径环境变量。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            app_root = Path(directory) / "中文安装目录" / "app"
+            tcl_root = app_root / "runtime" / "tcl"
+            tcl_directory = tcl_root / "tcl8.6"
+            tk_directory = tcl_root / "tk8.6"
+            tcl_directory.mkdir(parents=True)
+            tk_directory.mkdir()
+            (tcl_directory / "init.tcl").write_text("# test", encoding="ascii")
+            (tk_directory / "tk.tcl").write_text("# test", encoding="ascii")
+            environment = {}
+
+            configured = _configure_tk_runtime(
+                candidate_roots=[tcl_root],
+                environment=environment,
+                working_directory=app_root,
+            )
+
+            self.assertTrue(configured)
+            self.assertEqual(
+                environment["TCL_LIBRARY"], "runtime/tcl/tcl8.6"
+            )
+            self.assertEqual(environment["TK_LIBRARY"], "runtime/tcl/tk8.6")
 
     def test_incomplete_or_explicit_configuration_is_not_overwritten(self):
         """候选文件不完整时停止；用户显式配置时保持原值。"""

--- a/tests/test_desktop_assistant_cli.py
+++ b/tests/test_desktop_assistant_cli.py
@@ -87,6 +87,50 @@ class DesktopAssistantCommandTests(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         setup_mock.assert_called_once_with(confirmed=True, dry_run=False)
 
+    @patch("abaqus_codex.distribution_integration.integration_setup")
+    @patch("abaqus_codex.paths.is_private_runtime", return_value=True)
+    def test_installed_setup_routes_through_owned_integration_manifest(
+        self, private_runtime_mock, integration_mock
+    ):
+        """安装版后续补装插件时必须同步更新可卸载清单。"""
+
+        integration_mock.return_value = {
+            "plugin": {
+                "message": "安全插件已安装",
+                "target": r"C:\Users\test\abaqus_plugins\safe_material_action",
+                "backup": None,
+                "changed": True,
+            }
+        }
+
+        exit_code = main(["assistant-setup", "--yes"])
+
+        self.assertEqual(exit_code, 0)
+        private_runtime_mock.assert_called_once_with()
+        integration_mock.assert_called_once_with(confirmed=True, dry_run=False)
+
+    @patch("abaqus_codex.distribution_integration.integration_setup")
+    @patch("abaqus_codex.paths.is_private_runtime", return_value=True)
+    def test_installed_setup_dry_run_does_not_expect_plugin_dry_run_field(
+        self, private_runtime_mock, integration_mock
+    ):
+        """集成清单的插件子项不含 dry_run 也应能演练。"""
+
+        integration_mock.return_value = {
+            "plugin": {
+                "message": "演练完成",
+                "target": r"C:\Users\test\abaqus_plugins\safe_material_action",
+                "backup": None,
+                "changed": True,
+            }
+        }
+
+        exit_code = main(["assistant-setup", "--dry-run"])
+
+        self.assertEqual(exit_code, 0)
+        private_runtime_mock.assert_called_once_with()
+        integration_mock.assert_called_once_with(confirmed=False, dry_run=True)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_distribution_integration.py
+++ b/tests/test_distribution_integration.py
@@ -259,8 +259,8 @@ class DistributionIntegrationTests(unittest.TestCase):
                 manifest = data / MANIFEST_FILENAME
                 self.assertTrue(manifest.is_file())
                 payload = json.loads(manifest.read_text(encoding="utf-8"))
-                self.assertEqual(payload["user_data_root"], str(data.resolve()))
-                self.assertEqual(payload["codex_home"], str(codex.resolve()))
+                self.assertTrue(Path(payload["user_data_root"]).samefile(data))
+                self.assertTrue(Path(payload["codex_home"]).samefile(codex))
                 self.assertFalse(installed["plugin"]["eligible"])
 
                 removed = integration_remove(confirmed=True, data_root=data)

--- a/tests/test_distribution_integration.py
+++ b/tests/test_distribution_integration.py
@@ -1,0 +1,862 @@
+# -*- coding: utf-8 -*-
+"""离线验证安装版路径、Skill 恢复和 Abaqus 2021 插件门禁。"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from abaqus_codex.distribution_integration import (
+    DistributionIntegrationError,
+    MANIFEST_FILENAME,
+    _install_directory,
+    _next_recovery_path,
+    integration_remove,
+    integration_setup,
+)
+from abaqus_codex.paths import (
+    activate_user_python_packages,
+    is_private_runtime,
+    project_python_executable,
+    resource_root,
+    user_data_root,
+)
+
+
+def make_resources(root: Path) -> Path:
+    """创建最小但完整的离线发布资源。"""
+
+    (root / "configs").mkdir(parents=True)
+    skill = root / "skills" / "abaqus-modeling-guide"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("# 新 Skill\n", encoding="utf-8")
+    plugin = root / "abaqus_plugins" / "safe_material_action"
+    plugin.mkdir(parents=True)
+    (plugin / "safe_material_action_plugin.py").write_text(
+        "# plugin\n", encoding="utf-8"
+    )
+    (plugin / "safe_material_action_kernel.py").write_text(
+        "# kernel\n", encoding="utf-8"
+    )
+    return root
+
+
+def abaqus_result(version: str = "2021", usable: bool = True) -> dict[str, object]:
+    return {
+        "installed": usable,
+        "usable": usable,
+        "version": version if usable else None,
+        "python_version": "2.7.15" if usable else None,
+        "command": "abaqus.bat" if usable else None,
+    }
+
+
+class RuntimePathTests(unittest.TestCase):
+    """资源只读根与用户可写根不得混用。"""
+
+    def test_private_runtime_finds_application_resource_root(self):
+        """从 app/runtime/Lib/site-packages 向上能找到发布资源。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            app_root = make_resources(Path(directory) / "app")
+            module_path = app_root / "runtime" / "Lib" / "site-packages" / "abaqus_codex" / "paths.py"
+            module_path.parent.mkdir(parents=True)
+            module_path.write_text("# probe\n", encoding="utf-8")
+            with patch.dict(os.environ, {}, clear=True), patch(
+                "abaqus_codex.paths.__file__", str(module_path)
+            ), patch("abaqus_codex.paths.sys.executable", str(app_root / "runtime" / "python.exe")):
+                self.assertEqual(resource_root(), app_root.resolve())
+
+    def test_named_gui_executable_maps_to_private_console_python(self):
+        """派生 pip/MCP 时必须使用可承载 stdio 的 python.exe。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            app_root = make_resources(Path(directory) / "app")
+            runtime = app_root / "runtime"
+            runtime.mkdir()
+            gui_executable = runtime / "AbaqusCodexAssistant.exe"
+            console_python = runtime / "python.exe"
+            gui_executable.touch()
+            console_python.touch()
+            module_path = (
+                runtime
+                / "Lib"
+                / "site-packages"
+                / "abaqus_codex"
+                / "paths.py"
+            )
+            module_path.parent.mkdir(parents=True)
+            module_path.touch()
+            with patch.dict(os.environ, {}, clear=True), patch(
+                "abaqus_codex.paths.__file__", str(module_path)
+            ), patch(
+                "abaqus_codex.paths.sys.executable", str(gui_executable)
+            ):
+                self.assertEqual(
+                    project_python_executable(), console_python.resolve()
+                )
+
+    def test_private_runtime_ignores_stale_install_root_environment(self):
+        """官方 runtime 的完整自身资源不得被残留环境变量劫持。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            app_root = make_resources(root / "app")
+            stale_root = make_resources(root / "stale")
+            module_path = app_root / "runtime" / "Lib" / "site-packages" / "abaqus_codex" / "paths.py"
+            module_path.parent.mkdir(parents=True)
+            module_path.write_text("# runtime\n", encoding="utf-8")
+            executable = app_root / "runtime" / "python.exe"
+            executable.write_bytes(b"")
+            with patch.dict(
+                os.environ,
+                {"ABAQUS_CODEX_INSTALL_ROOT": str(stale_root)},
+                clear=False,
+            ), patch("abaqus_codex.paths.__file__", str(module_path)), patch(
+                "abaqus_codex.paths.sys.executable", str(executable)
+            ):
+                self.assertEqual(resource_root(), app_root.resolve())
+
+    def test_user_data_defaults_to_local_appdata(self):
+        with tempfile.TemporaryDirectory() as directory:
+            with patch.dict(
+                os.environ,
+                {"LOCALAPPDATA": directory, "ABAQUS_CODEX_USER_DATA_ROOT": ""},
+                clear=False,
+            ):
+                self.assertEqual(
+                    user_data_root(),
+                    Path(directory).resolve() / "AbaqusCodexAssistant",
+                )
+
+    def test_private_runtime_activates_only_its_user_package_directory(self):
+        """安装版使用私有解释器时才激活可写依赖目录。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            app_root = make_resources(root / "app")
+            module_path = (
+                app_root
+                / "runtime"
+                / "Lib"
+                / "site-packages"
+                / "abaqus_codex"
+                / "paths.py"
+            )
+            module_path.parent.mkdir(parents=True)
+            module_path.write_text("# probe\n", encoding="utf-8")
+            private_path = app_root / "runtime" / "python.exe"
+            local_data = root / "local-data"
+            isolated_sys_path = ["runtime-site-packages"]
+            with patch.dict(
+                os.environ,
+                {
+                    "LOCALAPPDATA": str(local_data),
+                    "ABAQUS_CODEX_USER_DATA_ROOT": "",
+                },
+                clear=False,
+            ), patch(
+                "abaqus_codex.paths.__file__", str(module_path)
+            ), patch(
+                "abaqus_codex.paths.sys.executable", str(private_path)
+            ), patch(
+                "abaqus_codex.paths.sys.path", isolated_sys_path
+            ):
+                self.assertTrue(is_private_runtime())
+                activated = activate_user_python_packages(create=True)
+
+            expected = (
+                local_data / "AbaqusCodexAssistant" / "python-packages"
+            ).resolve()
+            self.assertEqual(activated, expected)
+            self.assertEqual(isolated_sys_path[0], str(expected))
+            self.assertTrue(expected.is_dir())
+
+    def test_source_runtime_does_not_create_or_activate_user_packages(self):
+        """源码模式不修改 sys.path，也不创建安装版数据目录。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source_root = make_resources(root / "source")
+            module_path = source_root / "src" / "abaqus_codex" / "paths.py"
+            module_path.parent.mkdir(parents=True)
+            module_path.write_text("# probe\n", encoding="utf-8")
+            local_data = root / "local-data"
+            isolated_sys_path = ["source-tree"]
+            with patch.dict(
+                os.environ,
+                {
+                    "LOCALAPPDATA": str(local_data),
+                    "ABAQUS_CODEX_USER_DATA_ROOT": "",
+                },
+                clear=False,
+            ), patch(
+                "abaqus_codex.paths.__file__", str(module_path)
+            ), patch(
+                "abaqus_codex.paths.sys.executable",
+                str(root / "system-python" / "python.exe"),
+            ), patch(
+                "abaqus_codex.paths.sys.path", isolated_sys_path
+            ):
+                self.assertFalse(is_private_runtime())
+                activated = activate_user_python_packages(create=True)
+
+            self.assertIsNone(activated)
+            self.assertEqual(isolated_sys_path, ["source-tree"])
+            self.assertFalse(
+                (
+                    local_data
+                    / "AbaqusCodexAssistant"
+                    / "python-packages"
+                ).exists()
+            )
+
+
+class DistributionIntegrationTests(unittest.TestCase):
+    """集成只操作当前用户目录，并且所有移除都可恢复。"""
+
+    def setUp(self):
+        self.headless_patcher = patch(
+            "abaqus_codex.mcp_setup.stop_managed_headless_bridge_for_uninstall",
+            return_value={"status": "not_running", "stopped": True},
+        )
+        self.registration_patcher = patch(
+            "abaqus_codex.mcp_setup.remove_managed_codex_registration",
+            return_value={"status": "not_registered", "removed": False},
+        )
+        self.headless_patcher.start()
+        self.registration_patcher.start()
+        self.addCleanup(self.headless_patcher.stop)
+        self.addCleanup(self.registration_patcher.stop)
+
+    def test_skill_install_manifest_and_recoverable_remove(self):
+        """新 Skill 安装后清单位于用户数据根，卸载只改名。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            resources = make_resources(root / "resources")
+            codex = root / "custom-codex"
+            data = root / "data"
+            profile = root / "profile"
+            with patch.dict(os.environ, {"USERPROFILE": str(profile)}), patch(
+                "abaqus_codex.distribution_integration.resource_root",
+                return_value=resources,
+            ), patch(
+                "abaqus_codex.distribution_integration.inspect_abaqus",
+                return_value=abaqus_result(usable=False),
+            ):
+                installed = integration_setup(
+                    confirmed=True, codex_home_path=codex, data_root=data
+                )
+                target = codex / "skills" / "abaqus-modeling-guide"
+                self.assertTrue((target / "SKILL.md").is_file())
+                self.assertFalse((profile / "abaqus_plugins").exists())
+                manifest = data / MANIFEST_FILENAME
+                self.assertTrue(manifest.is_file())
+                payload = json.loads(manifest.read_text(encoding="utf-8"))
+                self.assertEqual(payload["user_data_root"], str(data.resolve()))
+                self.assertEqual(payload["codex_home"], str(codex.resolve()))
+                self.assertFalse(installed["plugin"]["eligible"])
+
+                removed = integration_remove(confirmed=True, data_root=data)
+
+            self.assertFalse(target.exists())
+            self.assertEqual(removed["skill"]["status"], "moved_to_recovery")
+            self.assertTrue(Path(removed["skill"]["recovery_copy"]).is_dir())
+            self.assertFalse((data / MANIFEST_FILENAME).exists())
+            self.assertTrue(Path(removed["archived_manifest"]).is_file())
+            self.assertEqual(removed["headless_bridge"]["status"], "not_running")
+            self.assertEqual(removed["mcp_registration"]["status"], "not_registered")
+
+    def test_existing_skill_is_backed_up_and_restored(self):
+        """替换旧 Skill 前先完整备份，移除时恢复旧内容。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            resources = make_resources(root / "resources")
+            codex = root / "codex"
+            target = codex / "skills" / "abaqus-modeling-guide"
+            target.mkdir(parents=True)
+            (target / "SKILL.md").write_text("# 用户旧 Skill\n", encoding="utf-8")
+            data = root / "data"
+            with patch.dict(os.environ, {"USERPROFILE": str(root / "profile")}), patch(
+                "abaqus_codex.distribution_integration.resource_root",
+                return_value=resources,
+            ), patch(
+                "abaqus_codex.distribution_integration.inspect_abaqus",
+                return_value=abaqus_result(usable=False),
+            ):
+                installed = integration_setup(
+                    confirmed=True, codex_home_path=codex, data_root=data
+                )
+                backup = Path(str(installed["skill"]["backup"]))
+                self.assertEqual(backup.parent, data / "recovery" / "skill")
+                self.assertNotEqual(backup.parent, target.parent)
+                self.assertIn("用户旧", (backup / "SKILL.md").read_text(encoding="utf-8"))
+                removed = integration_remove(confirmed=True, data_root=data)
+
+            self.assertEqual(removed["skill"]["status"], "restored_backup")
+            self.assertIn("用户旧", (target / "SKILL.md").read_text(encoding="utf-8"))
+
+    def test_two_upgrades_keep_first_user_backup_for_uninstall(self):
+        """v1→v2 只生成升级恢复副本，卸载仍恢复安装前的用户 Skill。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            resources = make_resources(root / "resources")
+            codex = root / "codex"
+            target = codex / "skills" / "abaqus-modeling-guide"
+            target.mkdir(parents=True)
+            (target / "SKILL.md").write_text("# 用户原版\n", encoding="utf-8")
+            data = root / "data"
+            patches = (
+                patch.dict(os.environ, {"USERPROFILE": str(root / "profile")}),
+                patch(
+                    "abaqus_codex.distribution_integration.resource_root",
+                    return_value=resources,
+                ),
+                patch(
+                    "abaqus_codex.distribution_integration.inspect_abaqus",
+                    return_value=abaqus_result(usable=False),
+                ),
+            )
+            with patches[0], patches[1], patches[2]:
+                first = integration_setup(
+                    confirmed=True, codex_home_path=codex, data_root=data
+                )
+                first_backup = Path(str(first["skill"]["backup"]))
+                (resources / "skills" / "abaqus-modeling-guide" / "SKILL.md").write_text(
+                    "# 程序 v2\n", encoding="utf-8"
+                )
+                second = integration_setup(
+                    confirmed=True, codex_home_path=codex, data_root=data
+                )
+                self.assertEqual(Path(str(second["skill"]["backup"])), first_backup)
+                upgrades = [
+                    Path(value) for value in second["skill"]["upgrade_recoveries"]
+                ]
+                self.assertEqual(len(upgrades), 1)
+                self.assertTrue(upgrades[0].is_dir())
+                self.assertEqual(upgrades[0].parent, data / "recovery" / "skill")
+                self.assertNotEqual(upgrades[0].parent, target.parent)
+                removed = integration_remove(confirmed=True, data_root=data)
+
+            self.assertEqual(removed["skill"]["status"], "restored_backup")
+            self.assertIn("用户原版", (target / "SKILL.md").read_text(encoding="utf-8"))
+
+    @unittest.skipUnless(os.name == "nt", "Windows 路径大小写语义回归")
+    def test_upgrade_keeps_ownership_when_manifest_path_case_differs(self):
+        """清单仅改变路径大小写时仍须保留最初用户备份。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            resources = make_resources(root / "resources")
+            codex = root / "codex"
+            target = codex / "skills" / "abaqus-modeling-guide"
+            target.mkdir(parents=True)
+            (target / "SKILL.md").write_text("# 用户原版\n", encoding="utf-8")
+            data = root / "data"
+            with patch.dict(
+                os.environ, {"USERPROFILE": str(root / "profile")}
+            ), patch(
+                "abaqus_codex.distribution_integration.resource_root",
+                return_value=resources,
+            ), patch(
+                "abaqus_codex.distribution_integration.inspect_abaqus",
+                return_value=abaqus_result(usable=False),
+            ):
+                first = integration_setup(
+                    confirmed=True, codex_home_path=codex, data_root=data
+                )
+                first_backup = Path(str(first["skill"]["backup"]))
+                manifest_path = data / MANIFEST_FILENAME
+                payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+                payload["skill"]["target"] = str(payload["skill"]["target"]).swapcase()
+                manifest_path.write_text(
+                    json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+                    encoding="utf-8",
+                )
+                (resources / "skills" / "abaqus-modeling-guide" / "SKILL.md").write_text(
+                    "# 程序 v2\n", encoding="utf-8"
+                )
+
+                second = integration_setup(
+                    confirmed=True, codex_home_path=codex, data_root=data
+                )
+                self.assertEqual(Path(str(second["skill"]["backup"])), first_backup)
+                self.assertEqual(len(second["skill"]["upgrade_recoveries"]), 1)
+                removed = integration_remove(confirmed=True, data_root=data)
+
+            self.assertEqual(removed["skill"]["status"], "restored_backup")
+            self.assertIn(
+                "用户原版", (target / "SKILL.md").read_text(encoding="utf-8")
+            )
+
+    def test_existing_manifest_rejects_changed_codex_home(self):
+        """旧集成未移除时不能换 CODEX_HOME 后覆盖清单。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            resources = make_resources(root / "resources")
+            data = root / "data"
+            codex_one = root / "codex-one"
+            codex_two = root / "codex-two"
+            with patch.dict(os.environ, {"USERPROFILE": str(root / "profile")}), patch(
+                "abaqus_codex.distribution_integration.resource_root",
+                return_value=resources,
+            ), patch(
+                "abaqus_codex.distribution_integration.inspect_abaqus",
+                return_value=abaqus_result(usable=False),
+            ):
+                integration_setup(
+                    confirmed=True, codex_home_path=codex_one, data_root=data
+                )
+                original_manifest = (data / MANIFEST_FILENAME).read_text(encoding="utf-8")
+                with self.assertRaisesRegex(
+                    DistributionIntegrationError, "先.*integration-remove"
+                ):
+                    integration_setup(
+                        confirmed=True, codex_home_path=codex_two, data_root=data
+                    )
+
+            self.assertEqual(
+                (data / MANIFEST_FILENAME).read_text(encoding="utf-8"),
+                original_manifest,
+            )
+            self.assertFalse((codex_two / "skills").exists())
+
+    def test_legacy_sibling_backup_manifest_is_not_auto_migrated(self):
+        """旧清单没有隔离恢复区时，不自动移动历史备份。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            resources = make_resources(root / "resources")
+            codex = root / "codex"
+            data = root / "data"
+            with patch.dict(os.environ, {"USERPROFILE": str(root / "profile")}), patch(
+                "abaqus_codex.distribution_integration.resource_root",
+                return_value=resources,
+            ), patch(
+                "abaqus_codex.distribution_integration.inspect_abaqus",
+                return_value=abaqus_result(usable=False),
+            ):
+                integration_setup(
+                    confirmed=True, codex_home_path=codex, data_root=data
+                )
+                payload = json.loads((data / MANIFEST_FILENAME).read_text(encoding="utf-8"))
+                payload["skill"].pop("recovery_root", None)
+                legacy_backup = codex / "skills" / "abaqus-modeling-guide.backup-old"
+                payload["skill"]["backup"] = str(legacy_backup)
+                (data / MANIFEST_FILENAME).write_text(
+                    json.dumps(payload, ensure_ascii=False), encoding="utf-8"
+                )
+                with self.assertRaisesRegex(
+                    DistributionIntegrationError, "不会自动迁移"
+                ):
+                    integration_setup(
+                        confirmed=True, codex_home_path=codex, data_root=data
+                    )
+
+            self.assertFalse(legacy_backup.exists())
+
+    def test_symlink_target_is_rejected_without_following(self):
+        """安装不得把 Skill 换入链接指向的外部目录。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            resources = make_resources(root / "resources")
+            codex = root / "codex"
+            target = codex / "skills" / "abaqus-modeling-guide"
+            target.parent.mkdir(parents=True)
+            outside = root / "outside"
+            outside.mkdir()
+            (outside / "sentinel.txt").write_text("不能改", encoding="utf-8")
+            try:
+                target.symlink_to(outside, target_is_directory=True)
+            except OSError as error:
+                self.skipTest("当前系统不允许创建目录 symlink：{0}".format(error))
+            with patch.dict(os.environ, {"USERPROFILE": str(root / "profile")}), patch(
+                "abaqus_codex.distribution_integration.resource_root",
+                return_value=resources,
+            ), patch(
+                "abaqus_codex.distribution_integration.inspect_abaqus",
+                return_value=abaqus_result(usable=False),
+            ):
+                with self.assertRaisesRegex(
+                    DistributionIntegrationError, "符号链接|Windows 联接点"
+                ):
+                    integration_setup(
+                        confirmed=True,
+                        codex_home_path=codex,
+                        data_root=root / "data",
+                    )
+
+            self.assertEqual(
+                (outside / "sentinel.txt").read_text(encoding="utf-8"), "不能改"
+            )
+            self.assertFalse((root / "data" / MANIFEST_FILENAME).exists())
+
+    def test_remove_rejects_target_replaced_by_symlink(self):
+        """卸载前若目标被替换为链接，应整体失败关闭。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            resources = make_resources(root / "resources")
+            codex = root / "codex"
+            data = root / "data"
+            outside = root / "outside"
+            outside.mkdir()
+            (outside / "sentinel.txt").write_text("保留", encoding="utf-8")
+            with patch.dict(os.environ, {"USERPROFILE": str(root / "profile")}), patch(
+                "abaqus_codex.distribution_integration.resource_root",
+                return_value=resources,
+            ), patch(
+                "abaqus_codex.distribution_integration.inspect_abaqus",
+                return_value=abaqus_result(usable=False),
+            ):
+                integration_setup(
+                    confirmed=True, codex_home_path=codex, data_root=data
+                )
+                target = codex / "skills" / "abaqus-modeling-guide"
+                target.replace(root / "parked-managed-skill")
+                try:
+                    target.symlink_to(outside, target_is_directory=True)
+                except OSError as error:
+                    self.skipTest("当前系统不允许创建目录 symlink：{0}".format(error))
+                with self.assertRaisesRegex(
+                    DistributionIntegrationError, "符号链接|Windows 联接点"
+                ):
+                    integration_remove(confirmed=True, data_root=data)
+
+            self.assertTrue((data / MANIFEST_FILENAME).is_file())
+            self.assertEqual((outside / "sentinel.txt").read_text(encoding="utf-8"), "保留")
+
+    @unittest.skipUnless(
+        os.name == "nt" and callable(getattr(Path("."), "is_junction", None)),
+        "当前平台不提供 Windows junction 检测",
+    )
+    def test_junction_parent_is_rejected_when_available(self):
+        """Windows junction 不是 is_symlink，也必须在写入前被拦截。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            resources = make_resources(root / "resources")
+            real_codex = root / "real-codex"
+            real_codex.mkdir()
+            junction = root / "codex-junction"
+            completed = subprocess.run(
+                ["cmd.exe", "/d", "/c", "mklink", "/J", str(junction), str(real_codex)],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            )
+            if completed.returncode != 0 or not junction.is_junction():
+                self.skipTest("当前 Windows 环境无法创建 junction")
+            try:
+                with patch.dict(os.environ, {"USERPROFILE": str(root / "profile")}), patch(
+                    "abaqus_codex.distribution_integration.resource_root",
+                    return_value=resources,
+                ), patch(
+                    "abaqus_codex.distribution_integration.inspect_abaqus",
+                    return_value=abaqus_result(usable=False),
+                ):
+                    with self.assertRaisesRegex(
+                        DistributionIntegrationError, "Windows 联接点"
+                    ):
+                        integration_setup(
+                            confirmed=True,
+                            codex_home_path=junction,
+                            data_root=root / "data",
+                        )
+            finally:
+                if junction.exists() or junction.is_junction():
+                    os.rmdir(junction)
+
+    @unittest.skipUnless(
+        os.name == "nt" and callable(getattr(Path("."), "is_junction", None)),
+        "当前平台不提供 Windows junction 检测",
+    )
+    def test_nested_junction_in_source_manifest_is_rejected(self):
+        """指纹遍历在进入资源内部 junction 前就必须停止。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            resources = make_resources(root / "resources")
+            outside = root / "outside"
+            outside.mkdir()
+            (outside / "sentinel.txt").write_text("不读取", encoding="utf-8")
+            junction = resources / "skills" / "abaqus-modeling-guide" / "linked-data"
+            completed = subprocess.run(
+                ["cmd.exe", "/d", "/c", "mklink", "/J", str(junction), str(outside)],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            )
+            if completed.returncode != 0 or not junction.is_junction():
+                self.skipTest("当前 Windows 环境无法创建 junction")
+            try:
+                with patch.dict(os.environ, {"USERPROFILE": str(root / "profile")}), patch(
+                    "abaqus_codex.distribution_integration.resource_root",
+                    return_value=resources,
+                ), patch(
+                    "abaqus_codex.distribution_integration.inspect_abaqus",
+                    return_value=abaqus_result(usable=False),
+                ):
+                    with self.assertRaisesRegex(
+                        DistributionIntegrationError, "目录中含有.*Windows 联接点"
+                    ):
+                        integration_setup(
+                            confirmed=True,
+                            codex_home_path=root / "codex",
+                            data_root=root / "data",
+                        )
+            finally:
+                if junction.exists() or junction.is_junction():
+                    os.rmdir(junction)
+
+    def test_modified_managed_skill_is_preserved(self):
+        """用户改过的已安装 Skill 不能在卸载时被移走或覆盖。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            resources = make_resources(root / "resources")
+            codex = root / "codex"
+            data = root / "data"
+            with patch.dict(os.environ, {"USERPROFILE": str(root / "profile")}), patch(
+                "abaqus_codex.distribution_integration.resource_root",
+                return_value=resources,
+            ), patch(
+                "abaqus_codex.distribution_integration.inspect_abaqus",
+                return_value=abaqus_result(usable=False),
+            ):
+                integration_setup(confirmed=True, codex_home_path=codex, data_root=data)
+                target = codex / "skills" / "abaqus-modeling-guide"
+                (target / "user-note.txt").write_text("保留我", encoding="utf-8")
+                removed = integration_remove(confirmed=True, data_root=data)
+
+            self.assertEqual(removed["skill"]["status"], "preserved_modified")
+            self.assertEqual((target / "user-note.txt").read_text(encoding="utf-8"), "保留我")
+
+    def test_managed_mcp_cleanup_failure_keeps_manifest_and_integration(self):
+        """已证明所有权的 MCP 清理失败时必须让卸载器收到非零结果。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            resources = make_resources(root / "resources")
+            codex = root / "codex"
+            data = root / "data"
+            profile = root / "profile"
+            with patch.dict(os.environ, {"USERPROFILE": str(profile)}), patch(
+                "abaqus_codex.distribution_integration.resource_root",
+                return_value=resources,
+            ), patch(
+                "abaqus_codex.distribution_integration.inspect_abaqus",
+                return_value=abaqus_result(usable=False),
+            ):
+                integration_setup(
+                    confirmed=True, codex_home_path=codex, data_root=data
+                )
+                skill = codex / "skills" / "abaqus-modeling-guide"
+                with patch(
+                    "abaqus_codex.mcp_setup.stop_managed_headless_bridge_for_uninstall",
+                    return_value={"status": "not_running", "stopped": True},
+                ), patch(
+                    "abaqus_codex.mcp_setup.remove_managed_codex_registration",
+                    return_value={"status": "remove_failed", "removed": False},
+                ):
+                    with self.assertRaisesRegex(
+                        DistributionIntegrationError, "MCP 注册未能移除"
+                    ):
+                        integration_remove(confirmed=True, data_root=data)
+
+            self.assertTrue((data / MANIFEST_FILENAME).is_file())
+            self.assertTrue(skill.is_dir())
+
+    def test_headless_stop_failure_does_not_remove_mcp_registration(self):
+        """后台停止失败时不能先造成 Codex 注册的半清理。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            resources = make_resources(root / "resources")
+            codex = root / "codex"
+            data = root / "data"
+            with patch.dict(
+                os.environ, {"USERPROFILE": str(root / "profile")}
+            ), patch(
+                "abaqus_codex.distribution_integration.resource_root",
+                return_value=resources,
+            ), patch(
+                "abaqus_codex.distribution_integration.inspect_abaqus",
+                return_value=abaqus_result(usable=False),
+            ):
+                integration_setup(
+                    confirmed=True, codex_home_path=codex, data_root=data
+                )
+                with patch(
+                    "abaqus_codex.mcp_setup.stop_managed_headless_bridge_for_uninstall",
+                    return_value={
+                        "status": "stop_not_confirmed",
+                        "stopped": False,
+                    },
+                ), patch(
+                    "abaqus_codex.mcp_setup.remove_managed_codex_registration"
+                ) as remove_mock:
+                    with self.assertRaisesRegex(
+                        DistributionIntegrationError, "尚未确认停止"
+                    ):
+                        integration_remove(confirmed=True, data_root=data)
+
+            remove_mock.assert_not_called()
+            self.assertTrue((data / MANIFEST_FILENAME).is_file())
+
+    def test_manifest_failure_restores_previous_skill(self):
+        """清单无法落盘时，不能留下无法管理的替换结果。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            resources = make_resources(root / "resources")
+            codex = root / "codex"
+            target = codex / "skills" / "abaqus-modeling-guide"
+            target.mkdir(parents=True)
+            (target / "SKILL.md").write_text("# 原 Skill\n", encoding="utf-8")
+            with patch.dict(os.environ, {"USERPROFILE": str(root / "profile")}), patch(
+                "abaqus_codex.distribution_integration.resource_root",
+                return_value=resources,
+            ), patch(
+                "abaqus_codex.distribution_integration.inspect_abaqus",
+                return_value=abaqus_result(usable=False),
+            ), patch(
+                "abaqus_codex.distribution_integration._write_manifest",
+                side_effect=DistributionIntegrationError("测试写入失败"),
+            ):
+                with self.assertRaises(DistributionIntegrationError):
+                    integration_setup(
+                        confirmed=True,
+                        codex_home_path=codex,
+                        data_root=root / "data",
+                    )
+
+            self.assertIn("原 Skill", (target / "SKILL.md").read_text(encoding="utf-8"))
+
+    def test_safe_plugin_is_installed_only_for_verified_2021(self):
+        """2021 通过两次实时门禁才能写入安全插件。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            resources = make_resources(root / "resources")
+            profile = root / "profile"
+            with patch.dict(os.environ, {"USERPROFILE": str(profile)}), patch(
+                "abaqus_codex.distribution_integration.resource_root",
+                return_value=resources,
+            ), patch(
+                "abaqus_codex.distribution_integration.inspect_abaqus",
+                return_value=abaqus_result("2021"),
+            ), patch(
+                "abaqus_codex.safe_action_setup.inspect_abaqus",
+                return_value=abaqus_result("2021"),
+            ):
+                result = integration_setup(
+                    confirmed=True,
+                    codex_home_path=root / "codex",
+                    data_root=root / "data",
+                )
+
+            plugin = profile / "abaqus_plugins" / "safe_material_action"
+            self.assertTrue((plugin / "safe_material_action_kernel.py").is_file())
+            self.assertTrue(result["plugin"]["eligible"])
+            self.assertTrue(result["plugin"]["managed"])
+
+    def test_2022_never_calls_safe_plugin_installer(self):
+        """即使 Abaqus 2022 可用，也不写入仅验证过 2021 的插件。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            resources = make_resources(root / "resources")
+            with patch.dict(os.environ, {"USERPROFILE": str(root / "profile")}), patch(
+                "abaqus_codex.distribution_integration.resource_root",
+                return_value=resources,
+            ), patch(
+                "abaqus_codex.distribution_integration.inspect_abaqus",
+                return_value=abaqus_result("2022"),
+            ), patch(
+                "abaqus_codex.distribution_integration.setup_safe_action_plugin"
+            ) as setup_mock:
+                result = integration_setup(
+                    confirmed=True,
+                    codex_home_path=root / "codex",
+                    data_root=root / "data",
+                )
+
+            setup_mock.assert_not_called()
+            self.assertFalse(result["plugin"]["eligible"])
+            self.assertFalse((root / "profile" / "abaqus_plugins").exists())
+
+    def test_source_target_overlap_is_rejected(self):
+        """资源和目标互为祖先/子孙时，必须在复制前停止。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "source"
+            source.mkdir()
+            (source / "file.txt").write_text("data", encoding="utf-8")
+            with self.assertRaisesRegex(DistributionIntegrationError, "重叠"):
+                _install_directory(
+                    source,
+                    source / "nested-target",
+                    recovery_root=root / "recovery" / "skill",
+                    dry_run=False,
+                )
+            self.assertFalse((source / "nested-target").exists())
+
+    def test_cross_volume_stops_before_copy(self):
+        """无法原子移入恢复区时，不得先生成 .installing 副本。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "source"
+            source.mkdir()
+            (source / "file.txt").write_text("data", encoding="utf-8")
+            target = root / "active" / "managed"
+            with patch(
+                "abaqus_codex.distribution_integration._same_storage_volume",
+                return_value=False,
+            ), patch(
+                "abaqus_codex.distribution_integration.shutil.copytree"
+            ) as copy_mock:
+                with self.assertRaisesRegex(DistributionIntegrationError, "同一磁盘"):
+                    _install_directory(
+                        source,
+                        target,
+                        recovery_root=root / "data" / "recovery" / "skill",
+                        dry_run=False,
+                    )
+            copy_mock.assert_not_called()
+            self.assertEqual(list(target.parent.glob(".managed.installing-*")), [])
+
+    def test_recovery_name_collision_stays_in_recovery_root(self):
+        """同一秒的恢复名冲突也不能回落到活跃扫描目录。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            recovery = root / "data" / "recovery" / "skill"
+            recovery.mkdir(parents=True)
+            target = root / "codex" / "skills" / "guide"
+            with patch(
+                "abaqus_codex.distribution_integration._timestamp",
+                return_value="20260101-000000",
+            ):
+                first = _next_recovery_path(recovery, target, "backup")
+                first.mkdir()
+                second = _next_recovery_path(recovery, target, "backup")
+            self.assertEqual(second.parent, recovery)
+            self.assertNotEqual(second.parent, target.parent)
+            self.assertTrue(second.name.endswith("-001"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mcp_uninstall_cleanup.py
+++ b/tests/test_mcp_uninstall_cleanup.py
@@ -21,6 +21,7 @@ from abaqus_codex.mcp_setup import (
     remove_managed_codex_registration,
     stop_managed_headless_bridge_for_uninstall,
 )
+from abaqus_codex.paths import project_python_executable
 
 
 def managed_payload(target: Path) -> dict[str, object]:
@@ -32,7 +33,7 @@ def managed_payload(target: Path) -> dict[str, object]:
         "name": MCP_SERVER_NAME,
         "transport": {
             "type": "stdio",
-            "command": sys.executable,
+            "command": str(project_python_executable()),
             "args": [str(target / "mcp_guard.py")],
             "env": {
                 "ABAQUS_MCP_HOME": str(target),

--- a/tests/test_mcp_uninstall_cleanup.py
+++ b/tests/test_mcp_uninstall_cleanup.py
@@ -1,0 +1,211 @@
+# -*- coding: utf-8 -*-
+"""离线验证卸载只清理能够证明所有权的 MCP 状态。"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from abaqus_codex.mcp_headless import (
+    HEADLESS_PID_NAME,
+    HEADLESS_SCRIPT_NAME,
+    MANAGED_HEADLESS_MARKER,
+)
+from abaqus_codex.mcp_setup import (
+    MCP_SERVER_NAME,
+    remove_managed_codex_registration,
+    stop_managed_headless_bridge_for_uninstall,
+)
+
+
+def managed_payload(target: Path) -> dict[str, object]:
+    """生成与安装器固定注册命令一致的 Codex JSON。"""
+
+    vendor = target / "vendor"
+    vendor.mkdir(parents=True, exist_ok=True)
+    return {
+        "name": MCP_SERVER_NAME,
+        "transport": {
+            "type": "stdio",
+            "command": sys.executable,
+            "args": [str(target / "mcp_guard.py")],
+            "env": {
+                "ABAQUS_MCP_HOME": str(target),
+                "PYTHONPATH": str(vendor),
+            },
+            "cwd": None,
+            "env_vars": [],
+        },
+    }
+
+
+def completed(payload: object, returncode: int = 0) -> SimpleNamespace:
+    output = (
+        json.dumps(payload).encode("utf-8")
+        if returncode == 0
+        else b"server not found"
+    )
+    return SimpleNamespace(returncode=returncode, stdout=output)
+
+
+class ManagedMcpRegistrationRemovalTests(unittest.TestCase):
+    """用户修改过的 Codex 注册必须原样保留。"""
+
+    @patch("abaqus_codex.mcp_setup._run_command")
+    @patch("abaqus_codex.mcp_setup.subprocess.run")
+    @patch("abaqus_codex.mcp_setup._codex_candidates")
+    def test_exact_managed_registration_is_removed(
+        self, candidates_mock, run_mock, remove_mock
+    ):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory).resolve() / ".abaqus-mcp"
+            payload = managed_payload(target)
+            codex = Path(directory) / "codex.exe"
+            candidates_mock.return_value = [codex]
+            run_mock.return_value = completed(payload)
+
+            result = remove_managed_codex_registration(target)
+
+        self.assertTrue(result["removed"])
+        self.assertEqual(result["status"], "removed")
+        self.assertEqual(
+            run_mock.call_args.args[0],
+            [str(codex), "mcp", "get", MCP_SERVER_NAME, "--json"],
+        )
+        self.assertEqual(
+            remove_mock.call_args.args[0],
+            [str(codex), "mcp", "remove", MCP_SERVER_NAME],
+        )
+
+    @patch("abaqus_codex.mcp_setup._run_command")
+    @patch("abaqus_codex.mcp_setup.subprocess.run")
+    @patch("abaqus_codex.mcp_setup._codex_candidates")
+    def test_user_modified_registration_is_preserved(
+        self, candidates_mock, run_mock, remove_mock
+    ):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory).resolve() / ".abaqus-mcp"
+            base = managed_payload(target)
+            codex = Path(directory) / "codex.exe"
+            candidates_mock.return_value = [codex]
+            mutations = (
+                (
+                    "different executable",
+                    lambda data: data["transport"].update(command="python"),
+                ),
+                (
+                    "extra argument",
+                    lambda data: data["transport"]["args"].append("--user"),
+                ),
+                (
+                    "different home",
+                    lambda data: data["transport"]["env"].update(
+                        ABAQUS_MCP_HOME=str(target.parent)
+                    ),
+                ),
+                (
+                    "extra environment",
+                    lambda data: data["transport"]["env"].update(
+                        USER_SETTING="keep"
+                    ),
+                ),
+                (
+                    "custom cwd",
+                    lambda data: data["transport"].update(cwd=str(target)),
+                ),
+            )
+            for label, mutate in mutations:
+                with self.subTest(label=label):
+                    payload = json.loads(json.dumps(base))
+                    mutate(payload)
+                    run_mock.return_value = completed(payload)
+                    result = remove_managed_codex_registration(target)
+                    self.assertFalse(result["removed"])
+                    self.assertEqual(result["status"], "preserved_unmanaged")
+            remove_mock.assert_not_called()
+
+    @patch("abaqus_codex.mcp_setup._run_command")
+    @patch("abaqus_codex.mcp_setup.subprocess.run")
+    @patch("abaqus_codex.mcp_setup._codex_candidates")
+    def test_missing_registration_is_a_safe_noop(
+        self, candidates_mock, run_mock, remove_mock
+    ):
+        candidates_mock.return_value = [Path("codex.exe")]
+        run_mock.return_value = completed({}, returncode=1)
+
+        result = remove_managed_codex_registration(Path(".abaqus-mcp"))
+
+        self.assertFalse(result["removed"])
+        self.assertEqual(result["status"], "not_registered_or_unreadable")
+        remove_mock.assert_not_called()
+
+    @patch("abaqus_codex.mcp_setup.subprocess.run")
+    @patch("abaqus_codex.mcp_setup._codex_candidates", return_value=[])
+    def test_missing_codex_cli_is_a_safe_noop(self, candidates_mock, run_mock):
+        result = remove_managed_codex_registration(Path(".abaqus-mcp"))
+
+        self.assertFalse(result["removed"])
+        self.assertEqual(result["status"], "cli_unavailable")
+        run_mock.assert_not_called()
+
+
+class ManagedHeadlessStopTests(unittest.TestCase):
+    """卸载仅协作式停止带项目标记的后台桥接。"""
+
+    @patch("abaqus_codex.mcp_headless.stop_headless_bridge")
+    @patch("abaqus_codex.mcp_headless.inspect_headless_bridge")
+    def test_managed_bridge_receives_cooperative_stop(
+        self, inspect_mock, stop_mock
+    ):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory).resolve()
+            script = target / HEADLESS_SCRIPT_NAME
+            script.write_text(
+                "# {0}\n".format(MANAGED_HEADLESS_MARKER), encoding="utf-8"
+            )
+            (target / HEADLESS_PID_NAME).write_text(
+                json.dumps({"script": str(script), "launcher_pid": 123}),
+                encoding="utf-8",
+            )
+            inspect_mock.return_value = {"managed_process_running": True}
+            stop_mock.return_value = {"managed_process_running": False}
+
+            result = stop_managed_headless_bridge_for_uninstall(target)
+
+        self.assertTrue(result["stopped"])
+        self.assertEqual(result["status"], "stopped")
+        stop_mock.assert_called_once_with(target, timeout_seconds=20)
+
+    @patch("abaqus_codex.mcp_headless.stop_headless_bridge")
+    @patch("abaqus_codex.mcp_headless.inspect_headless_bridge")
+    def test_unmarked_bridge_is_not_touched(self, inspect_mock, stop_mock):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory).resolve()
+            (target / HEADLESS_SCRIPT_NAME).write_text(
+                "# user script\n", encoding="utf-8"
+            )
+            (target / HEADLESS_PID_NAME).write_text(
+                json.dumps(
+                    {
+                        "script": str(target / HEADLESS_SCRIPT_NAME),
+                        "launcher_pid": 123,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            inspect_mock.return_value = {"managed_process_running": True}
+
+            result = stop_managed_headless_bridge_for_uninstall(target)
+
+        self.assertFalse(result["stopped"])
+        self.assertEqual(result["status"], "preserved_unmanaged")
+        stop_mock.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -18,16 +18,25 @@ class ReleaseMetadataTests(unittest.TestCase):
     def test_python_and_public_metadata_match_alpha_release(self):
         """Python 使用 PEP 440 写法，公开发布名使用 alpha 写法。"""
 
-        self.assertEqual(__version__, "0.2.1a1")
+        self.assertEqual(__version__, "0.2.2a1")
         pyproject = (PROJECT_ROOT / "pyproject.toml").read_text(encoding="utf-8")
         citation = (PROJECT_ROOT / "CITATION.cff").read_text(encoding="utf-8")
         changelog = (PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
-        self.assertIn('version = "0.2.1a1"', pyproject)
-        self.assertIn('version: "0.2.1-alpha"', citation)
-        self.assertIn("## [0.2.1-alpha] - 2026-08-31", changelog)
+        builder = (PROJECT_ROOT / "installer" / "build_windows_setup.ps1").read_text(
+            encoding="ascii"
+        )
+        inno = (PROJECT_ROOT / "installer" / "windows_setup.iss").read_text(
+            encoding="ascii"
+        )
+        self.assertIn('version = "0.2.2a1"', pyproject)
+        self.assertIn('version: "0.2.2-alpha"', citation)
+        self.assertIn("## [0.2.2-alpha] - 2026-08-31", changelog)
+        self.assertIn("$AppVersion =", builder)
+        self.assertIn("AbaqusCodexAssistant-Setup-$AppVersion-x64", builder)
+        self.assertIn('#define AppVersion "0.2.2-alpha"', inno)
 
     def test_abaqus_plugins_show_the_same_minor_release(self):
-        """两个 Abaqus 菜单入口都应显示 0.2.1。"""
+        """两个 Abaqus 菜单入口都应显示 0.2.2。"""
 
         for relative in (
             "abaqus_plugins/ai_modeling_assistant/ai_modeling_assistant_plugin.py",
@@ -35,7 +44,7 @@ class ReleaseMetadataTests(unittest.TestCase):
         ):
             with self.subTest(relative=relative):
                 source = (PROJECT_ROOT / relative).read_text(encoding="utf-8")
-                self.assertIn('version="0.2.1"', source)
+                self.assertIn('version="0.2.2"', source)
 
 
 if __name__ == "__main__":

--- a/tests/test_safe_action_setup.py
+++ b/tests/test_safe_action_setup.py
@@ -116,7 +116,10 @@ class SafeActionSetupTests(unittest.TestCase):
             target = root / "plugins" / "safe_material_action"
 
             result = setup_safe_action_plugin(
-                confirmed=True, source=source, target=target
+                confirmed=True,
+                source=source,
+                target=target,
+                backup_root=root / "recovery" / "plugin",
             )
 
             self.assertTrue(result["changed"])
@@ -128,6 +131,31 @@ class SafeActionSetupTests(unittest.TestCase):
             )
 
     @patch("abaqus_codex.safe_action_setup.inspect_abaqus")
+    def test_existing_plain_file_target_is_preserved_and_rejected(
+        self, inspect_mock
+    ):
+        """普通文件不能被当成插件目录备份，否则卸载无法原样恢复。"""
+
+        inspect_mock.return_value = abaqus_result()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = make_plugin(root / "source")
+            target = root / "plugins" / "safe_material_action"
+            target.parent.mkdir()
+            target.write_text("用户文件", encoding="utf-8")
+
+            with self.assertRaisesRegex(SafeActionSetupError, "不是目录"):
+                setup_safe_action_plugin(
+                    confirmed=True,
+                    source=source,
+                    target=target,
+                    backup_root=root / "recovery" / "plugin",
+                )
+
+            self.assertEqual(target.read_text(encoding="utf-8"), "用户文件")
+            self.assertFalse((root / "recovery").exists())
+
+    @patch("abaqus_codex.safe_action_setup.inspect_abaqus")
     def test_identical_install_is_left_untouched(self, inspect_mock):
         """目标内容相同时应直接返回，不生成备份或临时目录。"""
 
@@ -135,16 +163,19 @@ class SafeActionSetupTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             source = make_plugin(root / "source")
-            target = make_plugin(root / "safe_material_action")
+            target = make_plugin(root / "plugins" / "safe_material_action")
 
             result = setup_safe_action_plugin(
-                confirmed=True, source=source, target=target
+                confirmed=True,
+                source=source,
+                target=target,
+                backup_root=root / "recovery" / "plugin",
             )
 
             self.assertFalse(result["changed"])
             self.assertIsNone(result["backup"])
-            self.assertEqual(list(root.glob("safe_material_action.backup-*")), [])
-            self.assertEqual(list(root.glob(".safe_material_action.installing-*")), [])
+            self.assertEqual(list(target.parent.glob("safe_material_action.backup-*")), [])
+            self.assertEqual(list(target.parent.glob(".safe_material_action.installing-*")), [])
 
     @patch("abaqus_codex.safe_action_setup.shutil.rmtree")
     @patch("abaqus_codex.safe_action_setup.inspect_abaqus")
@@ -157,15 +188,20 @@ class SafeActionSetupTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             source = make_plugin(root / "source", marker="new")
-            target = make_plugin(root / "safe_material_action", marker="old")
+            target = make_plugin(root / "plugins" / "safe_material_action", marker="old")
             (target / "user-note.txt").write_text("用户文件", encoding="utf-8")
 
             result = setup_safe_action_plugin(
-                confirmed=True, source=source, target=target
+                confirmed=True,
+                source=source,
+                target=target,
+                backup_root=root / "recovery" / "plugin",
             )
 
             backup = Path(str(result["backup"]))
             self.assertTrue(backup.is_dir())
+            self.assertEqual(backup.parent, root / "recovery" / "plugin")
+            self.assertNotEqual(backup.parent, target.parent)
             self.assertIn(".backup-", backup.name)
             self.assertEqual(
                 (backup / "user-note.txt").read_text(encoding="utf-8"),
@@ -224,6 +260,23 @@ class SafeActionSetupTests(unittest.TestCase):
                 )
 
             self.assertFalse(target.exists())
+
+    @patch("abaqus_codex.safe_action_setup.inspect_abaqus")
+    def test_source_and_target_ancestry_overlap_is_rejected(self, inspect_mock):
+        """插件安装不得把目标放入资源内部，也不得反过来。"""
+
+        inspect_mock.return_value = abaqus_result()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = make_plugin(root / "source")
+            with self.assertRaisesRegex(SafeActionSetupError, "互为父目录"):
+                setup_safe_action_plugin(
+                    confirmed=True,
+                    source=source,
+                    target=source / "nested-target",
+                    backup_root=root / "recovery" / "plugin",
+                )
+            self.assertFalse((source / "nested-target").exists())
 
     def test_default_target_uses_userprofile(self):
         """Windows 默认路径应明确落在当前用户的 abaqus_plugins 下。"""

--- a/tests/test_windows_setup_builder.py
+++ b/tests/test_windows_setup_builder.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+"""Offline checks for the self-contained Windows Setup build definition."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+BUILD_SCRIPT = PROJECT_ROOT / "installer" / "build_windows_setup.ps1"
+INNO_SCRIPT = PROJECT_ROOT / "installer" / "windows_setup.iss"
+
+
+class WindowsSetupBuilderTests(unittest.TestCase):
+    """Keep the public Setup reproducible, offline at install time, and scoped."""
+
+    def test_builder_is_powershell_51_ascii_and_accepts_local_tools(self):
+        content = BUILD_SCRIPT.read_bytes()
+        self.assertTrue(content)
+        self.assertTrue(all(byte < 128 for byte in content))
+        text = content.decode("ascii")
+        self.assertIn("[string]$PythonArchive", text)
+        self.assertIn("[string]$InnoCompiler", text)
+        self.assertIn("Set-StrictMode -Version Latest", text)
+
+    def test_builder_pins_and_verifies_official_python_runtime(self):
+        text = BUILD_SCRIPT.read_text(encoding="ascii")
+        self.assertIn("python-3.12.10-amd64.zip", text)
+        self.assertIn("https://www.python.org/ftp/python/", text)
+        self.assertIn(
+            "8649692DE846C56A7189D6DAE5C322AB20DEB1B5908B6F39426B62A36F39415D",
+            text,
+        )
+        self.assertIn("Get-FileHash", text)
+        self.assertIn("SHA256 mismatch", text)
+
+    def test_builder_pins_and_verifies_inno_compiler(self):
+        text = BUILD_SCRIPT.read_text(encoding="ascii")
+        self.assertIn(
+            "0A8757031B33777E4C9CBFFEE40F11A5062B36D25CBE144C1DB73B6102B80AD7",
+            text,
+        )
+        self.assertIn("Get-AuthenticodeSignature", text)
+        self.assertIn("Pyrsys B.V.", text)
+        self.assertIn("ISCC.exe SHA256 mismatch", text)
+
+    def test_builder_derives_and_cross_checks_public_version(self):
+        text = BUILD_SCRIPT.read_text(encoding="ascii")
+        self.assertIn("$PackageVersion", text)
+        self.assertIn("the expected PEP 440 alpha form", text)
+        self.assertIn("does not match pyproject.toml", text)
+        self.assertIn("CITATION.cff does not match", text)
+        self.assertIn("/DReleaseSerial=$ReleaseSerial", text)
+
+    def test_builder_stages_full_runtime_project_and_hash(self):
+        text = BUILD_SCRIPT.read_text(encoding="ascii")
+        self.assertIn('Join-Path $runtimeRoot "Lib\\site-packages"', text)
+        self.assertIn('Join-Path $stagingRoot "AbaqusCodexAssistant.exe"', text)
+        self.assertIn('installer\\windows_launcher.cs', text)
+        self.assertIn("Microsoft.NET\\Framework64\\v4.0.30319\\csc.exe", text)
+        self.assertIn("/target:winexe", text)
+        self.assertIn("expected valid Microsoft signature", text)
+        self.assertNotIn(
+            'Copy-Item -LiteralPath (Join-Path $runtimeRoot "pythonw.exe")',
+            text,
+        )
+        self.assertIn('"configs", "skills", "abaqus_plugins", "docs"', text)
+        self.assertIn('"LICENSE"', text)
+        self.assertIn('Join-Path $runtimeRoot "Doc"', text)
+        self.assertIn('Filter "*.exe"', text)
+        self.assertIn('"$($setup.FullName).sha256"', text)
+
+    def test_builder_exports_only_clean_git_tracked_release_files(self):
+        text = BUILD_SCRIPT.read_text(encoding="ascii")
+        self.assertIn("status --porcelain --untracked-files=normal", text)
+        self.assertIn("the release worktree is not clean", text)
+        self.assertIn("archive --format=zip", text)
+        self.assertIn("forbidden private or Abaqus file", text)
+        self.assertIn('"user_profile.json", "local_ai_rectangle.json"', text)
+        self.assertNotIn('Join-Path $projectRoot "src\\abaqus_codex"', text)
+
+    def test_builder_only_recursively_cleans_guarded_build_children(self):
+        text = BUILD_SCRIPT.read_text(encoding="ascii")
+        self.assertIn("function Assert-BuildChild", text)
+        self.assertIn("function Reset-BuildDirectory", text)
+        self.assertIn("refusing to modify a path outside", text)
+        self.assertNotIn("Remove-Item -LiteralPath $projectRoot", text)
+        self.assertNotIn("Remove-Item -LiteralPath $buildRoot", text)
+
+    def test_inno_installs_per_user_and_launches_bundled_runtime(self):
+        text = INNO_SCRIPT.read_text(encoding="ascii")
+        self.assertIn(r"DefaultDirName={localappdata}\Programs\AbaqusCodexAssistant", text)
+        self.assertIn("PrivilegesRequired=lowest", text)
+        self.assertIn("ArchitecturesAllowed=x64compatible", text)
+        self.assertIn(
+            r'Filename: "{app}\AbaqusCodexAssistant.exe"', text
+        )
+        self.assertNotIn(
+            r'Filename: "{app}\runtime\pythonw.exe"', text
+        )
+        self.assertNotIn(
+            r'Parameters: "-I -m abaqus_codex assistant"', text
+        )
+        self.assertIn("function InitializeSetup", text)
+        self.assertIn("A newer Abaqus Codex Assistant is already installed", text)
+
+    def test_named_application_is_a_real_fixed_command_launcher(self):
+        launcher = (
+            PROJECT_ROOT / "installer" / "windows_launcher.cs"
+        ).read_text(encoding="ascii")
+        self.assertIn('"runtime",', launcher)
+        self.assertIn('"pythonw.exe"', launcher)
+        self.assertIn('start.Arguments = "-I -m abaqus_codex assistant"', launcher)
+        self.assertIn("Process.Start(start)", launcher)
+
+    def test_inno_runs_owned_integration_setup_and_removal(self):
+        text = INNO_SCRIPT.read_text(encoding="ascii")
+        self.assertIn("function RunIntegration", text)
+        self.assertIn("'-I ' + Arguments", text)
+        self.assertIn("integration-setup --yes", text)
+        self.assertIn('--data-root "', text)
+        self.assertIn(r"{localappdata}\AbaqusCodexAssistant", text)
+        self.assertIn("RaiseException", text)
+        self.assertIn("procedure CurUninstallStepChanged", text)
+        self.assertIn("integration-remove --yes", text)
+        self.assertIn("MB_ABORTRETRYIGNORE", text)
+        self.assertIn("if UninstallSilent then", text)
+        self.assertNotIn("[UninstallRun]", text)
+        self.assertNotIn("Invoke-WebRequest", text)
+        self.assertNotIn("DownloadTemporaryFile", text)
+
+    def test_inno_rejects_application_and_user_integration_path_overlap(self):
+        text = INNO_SCRIPT.read_text(encoding="ascii")
+        self.assertIn("function PathsOverlap", text)
+        self.assertIn("function NextButtonClick", text)
+        self.assertIn("WizardDirValue", text)
+        self.assertIn("skills\\abaqus-modeling-guide", text)
+        self.assertIn("abaqus_plugins\\safe_material_action", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -145,6 +145,10 @@ class AutomationVersionGateTests(unittest.TestCase):
                     "abaqus_codex.workflow.subprocess.run",
                     return_value=completed,
                 ) as run_mock,
+                patch(
+                    "abaqus_codex.workflow.activate_user_python_packages",
+                    return_value=root / "user-packages",
+                ),
             ):
                 with self.assertRaisesRegex(RuntimeError, "Abaqus 返回退出码"):
                     run_analysis(
@@ -156,6 +160,11 @@ class AutomationVersionGateTests(unittest.TestCase):
         child_environment = run_mock.call_args.kwargs["env"]
         self.assertEqual(
             child_environment["ABAQUS_BAT_PATH"], checked_command
+        )
+        self.assertTrue(
+            child_environment["PYTHONPATH"].startswith(
+                str(root / "user-packages")
+            )
         )
 
 


### PR DESCRIPTION
## 目标\n\n让普通用户只需下载并运行一个 Setup.exe，随后通过真正的 AbaqusCodexAssistant.exe 启动应用，无需自行安装项目 Python 或 Git。\n\n## 主要变化\n\n- 打包官方 CPython 3.12 私有运行时和 Tk\n- 新增真实 Windows GUI 启动器及桌面快捷方式\n- 安装时自动部署 Codex Skill，并仅对已验证的 Abaqus 2021 安全插件执行自动集成\n- 增加环境检查、严格年份 abqpy 指引和受管 MCP 清理\n- 用户数据与程序目录分离；升级、卸载均保留可恢复副本\n- 防护路径重叠、junction/symlink、跨卷移动及降级安装\n\n## 验证\n\n- 371 项测试通过\n- Inno Setup 6.7.3 实际编译成功\n- 真实 AbaqusCodexAssistant.exe 已拉起私有 Python/Tk 应用\n- 发布载荷未包含用户 CAE/ODB、账号或本机配置\n- Setup SHA256: 2FFF8E601A2D906F6E9E7E9FC7A475A12E242D4EE7C68F7CA860580249114AE2