### PR TITLE
fix: 修复安装器 Windows 用户目录常量

### DIFF
--- a/installer/windows_setup.iss
+++ b/installer/windows_setup.iss
@@ -95,6 +95,7 @@ end;
 function NextButtonClick(CurPageID: Integer): Boolean;
 var
   CodexHome: String;
+  UserProfileRoot: String;
   SkillTarget: String;
   PluginTarget: String;
 begin
@@ -102,10 +103,25 @@ begin
   if CurPageID <> wpSelectDir then
     Exit;
   CodexHome := GetEnv('CODEX_HOME');
+  UserProfileRoot := GetEnv('USERPROFILE');
   if CodexHome = '' then
-    CodexHome := ExpandConstant('{userprofile}\.codex');
+  begin
+    if UserProfileRoot = '' then
+    begin
+      MsgBox('Windows USERPROFILE is not available; Setup cannot locate your Codex folder.', mbError, MB_OK);
+      Result := False;
+      Exit;
+    end;
+    CodexHome := AddBackslash(UserProfileRoot) + '.codex';
+  end;
   SkillTarget := AddBackslash(CodexHome) + 'skills\abaqus-modeling-guide';
-  PluginTarget := ExpandConstant('{userprofile}\abaqus_plugins\safe_material_action');
+  if UserProfileRoot = '' then
+  begin
+    MsgBox('Windows USERPROFILE is not available; Setup cannot locate the Abaqus plug-in folder.', mbError, MB_OK);
+    Result := False;
+    Exit;
+  end;
+  PluginTarget := AddBackslash(UserProfileRoot) + 'abaqus_plugins\safe_material_action';
   if PathsOverlap(WizardDirValue, SkillTarget) or
     PathsOverlap(WizardDirValue, PluginTarget) then
   begin

--- a/tests/test_windows_setup_builder.py
+++ b/tests/test_windows_setup_builder.py
@@ -104,6 +104,8 @@ class WindowsSetupBuilderTests(unittest.TestCase):
         )
         self.assertIn("function InitializeSetup", text)
         self.assertIn("A newer Abaqus Codex Assistant is already installed", text)
+        self.assertNotIn("{userprofile}", text)
+        self.assertIn("GetEnv('USERPROFILE')", text)
 
     def test_named_application_is_a_real_fixed_command_launcher(self):
         launcher = (


### PR DESCRIPTION
修复朋友反馈的安装启动错误：Inno Setup 不支持 {userprofile} 常量，改为读取 Windows USERPROFILE 环境变量。新增回归测试，371 项本地测试通过。